### PR TITLE
feat: P1 documentation dimension scorer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+llm = [
+    "anthropic>=0.39.0",
+]
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",

--- a/scorecard/dimensions/documentation.py
+++ b/scorecard/dimensions/documentation.py
@@ -1,0 +1,391 @@
+"""Documentation dimension scorer.
+
+Evaluates whether code is adequately documented for someone else to
+understand it. Two modes:
+- LLM judge (Claude API) for nuanced evaluation
+- Rule-based fallback (docstring presence + comment density) when LLM unavailable
+"""
+
+import ast
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+
+from shared.models import Dimension, DimensionScore, ScoringMethod
+
+# --- LLM Judge ---
+
+_LLM_JUDGE_PROMPT = """\
+You are evaluating Python code documentation quality. Score each criterion 0.0-1.0.
+
+IMPORTANT: Simple, obvious code (like `x = 1` or `return a + b`) does NOT need \
+comments. Only penalize missing documentation when the logic is genuinely non-obvious.
+
+Code to evaluate:
+```python
+{code}
+```
+
+Criteria:
+1. logic_explanation (weight 0.35): Are complex/non-obvious parts explained? \
+Score 1.0 if all code is simple/obvious OR if complex parts have comments.
+2. function_docs (weight 0.25): Do public functions have docstrings describing \
+their purpose? Score 1.0 if functions are trivially obvious or have docstrings.
+3. purpose_docs (weight 0.25): Is there a module docstring or top-level comment \
+explaining what this code does? Score 1.0 if the code's purpose is obvious from \
+naming alone.
+4. comment_accuracy (weight 0.15): Do existing comments match what the code \
+actually does? Score 1.0 if there are no comments or all comments are accurate.
+
+Return ONLY valid JSON (no markdown fencing):
+{{"logic_explanation": 0.0, "function_docs": 0.0, "purpose_docs": 0.0, \
+"comment_accuracy": 0.0, "reasoning": "..."}}
+"""
+
+_LLM_JUDGE_WEIGHTS = {
+    "logic_explanation": 0.35,
+    "function_docs": 0.25,
+    "purpose_docs": 0.25,
+    "comment_accuracy": 0.15,
+}
+
+
+@dataclass
+class LLMJudgeResult:
+    """Result from the LLM judge."""
+
+    logic_explanation: float
+    function_docs: float
+    purpose_docs: float
+    comment_accuracy: float
+    reasoning: str
+
+    @property
+    def weighted_score(self) -> float:
+        total = 0.0
+        for key, weight in _LLM_JUDGE_WEIGHTS.items():
+            total += getattr(self, key) * weight
+        return min(max(total, 0.0), 1.0)
+
+
+def _call_llm_judge(code: str, model: str = "claude-sonnet-4-5-20250514") -> LLMJudgeResult | None:
+    """Call the Claude API to judge documentation quality.
+
+    Returns None if the call fails for any reason.
+    """
+    try:
+        import anthropic
+    except ImportError:
+        return None
+
+    try:
+        client = anthropic.Anthropic()
+        response = client.messages.create(
+            model=model,
+            max_tokens=512,
+            messages=[
+                {"role": "user", "content": _LLM_JUDGE_PROMPT.format(code=code[:4000])},
+            ],
+        )
+        text = response.content[0].text.strip()
+        # Strip markdown fencing if present
+        if text.startswith("```"):
+            text = re.sub(r"^```(?:json)?\n?", "", text)
+            text = re.sub(r"\n?```$", "", text)
+
+        data = json.loads(text)
+        return LLMJudgeResult(
+            logic_explanation=_clamp(data.get("logic_explanation", 0.5)),
+            function_docs=_clamp(data.get("function_docs", 0.5)),
+            purpose_docs=_clamp(data.get("purpose_docs", 0.5)),
+            comment_accuracy=_clamp(data.get("comment_accuracy", 0.5)),
+            reasoning=data.get("reasoning", ""),
+        )
+    except Exception:
+        return None
+
+
+def _clamp(value: float) -> float:
+    """Clamp a value to 0.0-1.0."""
+    try:
+        return min(max(float(value), 0.0), 1.0)
+    except (TypeError, ValueError):
+        return 0.5
+
+
+# --- Rule-based Fallback ---
+
+
+@dataclass
+class FallbackCheck:
+    """Result of a single fallback documentation check."""
+
+    name: str
+    score: float
+    weight: float
+    details: str
+
+
+@dataclass
+class FallbackReport:
+    """Aggregated fallback results."""
+
+    checks: list[FallbackCheck] = field(default_factory=list)
+
+    @property
+    def total_score(self) -> float:
+        total_weight = sum(c.weight for c in self.checks)
+        if total_weight == 0:
+            return 0.0
+        weighted = sum(c.score * c.weight for c in self.checks)
+        return min(weighted / total_weight, 1.0)
+
+    @property
+    def details_text(self) -> str:
+        lines = []
+        for c in self.checks:
+            pct = int(c.score * 100)
+            lines.append(f"[{pct}%] {c.name}: {c.details}")
+        return "; ".join(lines)
+
+
+def check_module_docstring(tree: ast.Module) -> FallbackCheck:
+    """Check for a module-level docstring."""
+    has_docstring = (
+        tree.body
+        and isinstance(tree.body[0], ast.Expr)
+        and isinstance(tree.body[0].value, ast.Constant)
+        and isinstance(tree.body[0].value.value, str)
+    )
+    if has_docstring:
+        return FallbackCheck(
+            name="module_docstring",
+            score=1.0,
+            weight=0.25,
+            details="Module docstring present",
+        )
+    return FallbackCheck(
+        name="module_docstring",
+        score=0.0,
+        weight=0.25,
+        details="No module docstring",
+    )
+
+
+def check_function_docstrings(tree: ast.Module) -> FallbackCheck:
+    """Check that public functions have docstrings."""
+    total = 0
+    documented = 0
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            # Skip private/dunder methods
+            if node.name.startswith("_"):
+                continue
+            total += 1
+            if (
+                node.body
+                and isinstance(node.body[0], ast.Expr)
+                and isinstance(node.body[0].value, ast.Constant)
+                and isinstance(node.body[0].value.value, str)
+            ):
+                documented += 1
+
+    if total == 0:
+        return FallbackCheck(
+            name="function_docstrings",
+            score=1.0,
+            weight=0.25,
+            details="No public functions to check",
+        )
+
+    ratio = documented / total
+    undocumented = total - documented
+    if undocumented == 0:
+        detail = f"All {total} public functions documented"
+    else:
+        detail = f"{undocumented}/{total} public functions lack docstrings"
+
+    return FallbackCheck(
+        name="function_docstrings",
+        score=ratio,
+        weight=0.25,
+        details=detail,
+    )
+
+
+def check_comment_density(code: str) -> FallbackCheck:
+    """Check comment density as a proxy for logic explanation.
+
+    Targets 5-15% comment lines. Simple code with few comments is fine;
+    complex code with zero comments is not.
+    """
+    lines = code.splitlines()
+    code_lines = [line for line in lines if line.strip() and not line.strip().startswith("#")]
+    comment_lines = [line for line in lines if line.strip().startswith("#")]
+    inline_comments = sum(1 for line in code_lines if "#" in line)
+    total_comments = len(comment_lines) + inline_comments
+    total_code = len(code_lines)
+
+    if total_code == 0:
+        return FallbackCheck(
+            name="comment_density",
+            score=1.0,
+            weight=0.35,
+            details="No code lines to check",
+        )
+
+    density = total_comments / total_code
+
+    # Simple heuristic: 0% comments = 0.3 (some code is self-documenting),
+    # 5%+ = 1.0 (adequate), scale linearly between
+    if density >= 0.05:
+        score = 1.0
+    else:
+        score = 0.3 + (density / 0.05) * 0.7
+
+    return FallbackCheck(
+        name="comment_density",
+        score=score,
+        weight=0.35,
+        details=f"{total_comments} comments in {total_code} code lines ({density:.0%} density)",
+    )
+
+
+def check_class_docstrings(tree: ast.Module) -> FallbackCheck:
+    """Check that classes have docstrings."""
+    total = 0
+    documented = 0
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            if node.name.startswith("_"):
+                continue
+            total += 1
+            if (
+                node.body
+                and isinstance(node.body[0], ast.Expr)
+                and isinstance(node.body[0].value, ast.Constant)
+                and isinstance(node.body[0].value.value, str)
+            ):
+                documented += 1
+
+    if total == 0:
+        return FallbackCheck(
+            name="class_docstrings",
+            score=1.0,
+            weight=0.15,
+            details="No public classes to check",
+        )
+
+    ratio = documented / total
+    undocumented = total - documented
+    if undocumented == 0:
+        detail = f"All {total} public classes documented"
+    else:
+        detail = f"{undocumented}/{total} public classes lack docstrings"
+
+    return FallbackCheck(
+        name="class_docstrings",
+        score=ratio,
+        weight=0.15,
+        details=detail,
+    )
+
+
+def _score_fallback(code: str, tree: ast.Module) -> tuple[float, str]:
+    """Score documentation using rule-based fallback."""
+    report = FallbackReport()
+    report.checks.append(check_module_docstring(tree))
+    report.checks.append(check_function_docstrings(tree))
+    report.checks.append(check_comment_density(code))
+    report.checks.append(check_class_docstrings(tree))
+    return report.total_score, report.details_text
+
+
+# --- Cache ---
+
+_score_cache: dict[str, DimensionScore] = {}
+
+
+def _cache_key(code: str) -> str:
+    return hashlib.sha256(code.encode()).hexdigest()
+
+
+def clear_cache() -> None:
+    """Clear the documentation score cache."""
+    _score_cache.clear()
+
+
+# --- Scorer ---
+
+
+class DocumentationScorer:
+    """Score code documentation quality.
+
+    Primary: LLM judge (Claude API) for nuanced evaluation.
+    Fallback: Rule-based heuristic when LLM is unavailable.
+    Results are cached by code content hash.
+    """
+
+    def __init__(self, use_llm: bool = True, model: str = "claude-sonnet-4-5-20250514"):
+        self.use_llm = use_llm
+        self.model = model
+
+    def score(self, code: str, filename: str = "") -> DimensionScore:
+        """Score documentation quality. Returns 0.0-1.0."""
+        if not code or not code.strip():
+            return DimensionScore(
+                dimension=Dimension.DOCUMENTATION,
+                score=0.0,
+                method=ScoringMethod.LLM_JUDGE,
+                details="Empty code",
+            )
+
+        # Check cache
+        key = _cache_key(code)
+        if key in _score_cache:
+            return _score_cache[key]
+
+        try:
+            tree = ast.parse(code)
+        except SyntaxError:
+            result = DimensionScore(
+                dimension=Dimension.DOCUMENTATION,
+                score=0.0,
+                method=ScoringMethod.RULE_BASED,
+                details="SyntaxError — cannot analyze documentation",
+            )
+            _score_cache[key] = result
+            return result
+
+        # Try LLM judge first
+        if self.use_llm:
+            llm_result = _call_llm_judge(code, model=self.model)
+            if llm_result is not None:
+                result = DimensionScore(
+                    dimension=Dimension.DOCUMENTATION,
+                    score=llm_result.weighted_score,
+                    method=ScoringMethod.LLM_JUDGE,
+                    details=llm_result.reasoning,
+                    metadata={
+                        "logic_explanation": llm_result.logic_explanation,
+                        "function_docs": llm_result.function_docs,
+                        "purpose_docs": llm_result.purpose_docs,
+                        "comment_accuracy": llm_result.comment_accuracy,
+                    },
+                )
+                _score_cache[key] = result
+                return result
+
+        # Fallback to rule-based
+        fallback_score, fallback_details = _score_fallback(code, tree)
+        result = DimensionScore(
+            dimension=Dimension.DOCUMENTATION,
+            score=fallback_score,
+            method=ScoringMethod.RULE_BASED,
+            details=f"(fallback) {fallback_details}",
+        )
+        _score_cache[key] = result
+        return result

--- a/tests/scorecard/test_documentation.py
+++ b/tests/scorecard/test_documentation.py
@@ -1,0 +1,399 @@
+"""Tests for documentation dimension scorer."""
+
+import ast
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scorecard.dimensions.documentation import (
+    DocumentationScorer,
+    LLMJudgeResult,
+    _clamp,
+    check_class_docstrings,
+    check_comment_density,
+    check_function_docstrings,
+    check_module_docstring,
+    clear_cache,
+)
+from shared.models import Dimension, ScoringMethod
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Clear cache before each test."""
+    clear_cache()
+    yield
+    clear_cache()
+
+
+def _parse(code: str) -> ast.Module:
+    return ast.parse(code)
+
+
+# --- Module Docstring ---
+
+
+class TestModuleDocstring:
+    def test_has_docstring(self):
+        code = '"""This module does stuff."""\nx = 1'
+        result = check_module_docstring(_parse(code))
+        assert result.score == 1.0
+
+    def test_no_docstring(self):
+        code = "x = 1\ny = 2"
+        result = check_module_docstring(_parse(code))
+        assert result.score == 0.0
+
+    def test_empty_module(self):
+        result = check_module_docstring(_parse(""))
+        assert result.score == 0.0
+
+
+# --- Function Docstrings ---
+
+
+class TestFunctionDocstrings:
+    def test_all_documented(self):
+        code = '''\
+def foo():
+    """Does foo."""
+    return 1
+
+def bar():
+    """Does bar."""
+    return 2
+'''
+        result = check_function_docstrings(_parse(code))
+        assert result.score == 1.0
+
+    def test_none_documented(self):
+        code = """\
+def foo():
+    return 1
+
+def bar():
+    return 2
+"""
+        result = check_function_docstrings(_parse(code))
+        assert result.score == 0.0
+        assert "2/2" in result.details
+
+    def test_partially_documented(self):
+        code = '''\
+def foo():
+    """Has docstring."""
+    return 1
+
+def bar():
+    return 2
+'''
+        result = check_function_docstrings(_parse(code))
+        assert result.score == pytest.approx(0.5)
+
+    def test_private_skipped(self):
+        code = """\
+def _private():
+    return 1
+
+def __dunder__():
+    return 2
+"""
+        result = check_function_docstrings(_parse(code))
+        assert result.score == 1.0
+        assert "No public functions" in result.details
+
+    def test_no_functions(self):
+        code = "x = 1"
+        result = check_function_docstrings(_parse(code))
+        assert result.score == 1.0
+
+
+# --- Comment Density ---
+
+
+class TestCommentDensity:
+    def test_well_commented(self):
+        code = """\
+# Initialize configuration
+config = load_config()
+# Process the data
+result = process(config)
+"""
+        result = check_comment_density(code)
+        assert result.score == 1.0
+
+    def test_no_comments(self):
+        code = """\
+x = 1
+y = 2
+z = x + y
+print(z)
+"""
+        result = check_comment_density(code)
+        # 0% density = 0.3 (self-documenting baseline)
+        assert result.score == pytest.approx(0.3)
+
+    def test_inline_comments_counted(self):
+        code = """\
+x = 1  # first value
+y = 2  # second value
+z = x + y
+"""
+        result = check_comment_density(code)
+        assert result.score > 0.3
+
+    def test_empty_code(self):
+        result = check_comment_density("")
+        assert result.score == 1.0
+
+    def test_density_in_details(self):
+        code = "x = 1\n# comment\ny = 2"
+        result = check_comment_density(code)
+        assert "density" in result.details
+
+
+# --- Class Docstrings ---
+
+
+class TestClassDocstrings:
+    def test_documented_class(self):
+        code = '''\
+class Foo:
+    """A foo class."""
+    pass
+'''
+        result = check_class_docstrings(_parse(code))
+        assert result.score == 1.0
+
+    def test_undocumented_class(self):
+        code = """\
+class Foo:
+    pass
+"""
+        result = check_class_docstrings(_parse(code))
+        assert result.score == 0.0
+
+    def test_private_class_skipped(self):
+        code = """\
+class _Internal:
+    pass
+"""
+        result = check_class_docstrings(_parse(code))
+        assert result.score == 1.0
+
+    def test_no_classes(self):
+        code = "x = 1"
+        result = check_class_docstrings(_parse(code))
+        assert result.score == 1.0
+
+
+# --- LLM Judge Result ---
+
+
+class TestLLMJudgeResult:
+    def test_weighted_score(self):
+        result = LLMJudgeResult(
+            logic_explanation=1.0,
+            function_docs=1.0,
+            purpose_docs=1.0,
+            comment_accuracy=1.0,
+            reasoning="All good",
+        )
+        assert result.weighted_score == 1.0
+
+    def test_weighted_score_mixed(self):
+        result = LLMJudgeResult(
+            logic_explanation=0.5,
+            function_docs=0.5,
+            purpose_docs=0.5,
+            comment_accuracy=0.5,
+            reasoning="Meh",
+        )
+        assert result.weighted_score == pytest.approx(0.5)
+
+    def test_weighted_score_zero(self):
+        result = LLMJudgeResult(
+            logic_explanation=0.0,
+            function_docs=0.0,
+            purpose_docs=0.0,
+            comment_accuracy=0.0,
+            reasoning="Bad",
+        )
+        assert result.weighted_score == 0.0
+
+
+class TestClamp:
+    def test_normal(self):
+        assert _clamp(0.5) == 0.5
+
+    def test_below(self):
+        assert _clamp(-1.0) == 0.0
+
+    def test_above(self):
+        assert _clamp(2.0) == 1.0
+
+    def test_invalid(self):
+        assert _clamp("bad") == 0.5
+
+
+# --- DocumentationScorer with LLM Mock ---
+
+
+class TestDocumentationScorerLLM:
+    def _mock_anthropic_response(self, data: dict):
+        """Create a mock Anthropic API response."""
+        mock_response = MagicMock()
+        mock_content = MagicMock()
+        mock_content.text = json.dumps(data)
+        mock_response.content = [mock_content]
+        return mock_response
+
+    @patch("scorecard.dimensions.documentation.anthropic", create=True)
+    def test_llm_judge_success(self, mock_anthropic_module):
+        mock_client = MagicMock()
+        mock_anthropic_module.Anthropic.return_value = mock_client
+        mock_client.messages.create.return_value = self._mock_anthropic_response(
+            {
+                "logic_explanation": 0.9,
+                "function_docs": 0.8,
+                "purpose_docs": 0.7,
+                "comment_accuracy": 1.0,
+                "reasoning": "Good documentation overall",
+            }
+        )
+
+        with patch("scorecard.dimensions.documentation._call_llm_judge") as mock_judge:
+            mock_judge.return_value = LLMJudgeResult(
+                logic_explanation=0.9,
+                function_docs=0.8,
+                purpose_docs=0.7,
+                comment_accuracy=1.0,
+                reasoning="Good documentation overall",
+            )
+            scorer = DocumentationScorer(use_llm=True)
+            score = scorer.score("def foo():\n    return 1", "test.py")
+
+            assert score.dimension == Dimension.DOCUMENTATION
+            assert score.method == ScoringMethod.LLM_JUDGE
+            assert 0.0 <= score.score <= 1.0
+            assert "Good documentation" in score.details
+
+    @patch("scorecard.dimensions.documentation._call_llm_judge")
+    def test_llm_failure_falls_back(self, mock_judge):
+        mock_judge.return_value = None
+
+        scorer = DocumentationScorer(use_llm=True)
+        score = scorer.score("def foo():\n    return 1", "test.py")
+
+        assert score.method == ScoringMethod.RULE_BASED
+        assert "(fallback)" in score.details
+
+    @patch("scorecard.dimensions.documentation._call_llm_judge")
+    def test_caching(self, mock_judge):
+        mock_judge.return_value = LLMJudgeResult(
+            logic_explanation=0.8,
+            function_docs=0.8,
+            purpose_docs=0.8,
+            comment_accuracy=0.8,
+            reasoning="Cached",
+        )
+        scorer = DocumentationScorer(use_llm=True)
+        code = "def foo():\n    return 1"
+
+        s1 = scorer.score(code, "test.py")
+        s2 = scorer.score(code, "test.py")
+
+        assert s1.score == s2.score
+        # LLM should only be called once due to caching
+        assert mock_judge.call_count == 1
+
+
+# --- DocumentationScorer Fallback Mode ---
+
+
+class TestDocumentationScorerFallback:
+    def test_fallback_mode(self):
+        scorer = DocumentationScorer(use_llm=False)
+        code = '''\
+"""Module docstring."""
+
+def foo():
+    """Does foo."""
+    # Important logic
+    return 1
+'''
+        score = scorer.score(code, "test.py")
+        assert score.method == ScoringMethod.RULE_BASED
+        assert "(fallback)" in score.details
+        assert score.score > 0.5
+
+    def test_empty_code(self):
+        scorer = DocumentationScorer(use_llm=False)
+        score = scorer.score("", "empty.py")
+        assert score.score == 0.0
+        assert "Empty" in score.details
+
+    def test_whitespace_only(self):
+        scorer = DocumentationScorer(use_llm=False)
+        score = scorer.score("   \n\n  ", "empty.py")
+        assert score.score == 0.0
+
+    def test_syntax_error(self):
+        scorer = DocumentationScorer(use_llm=False)
+        score = scorer.score("def broken( return", "bad.py")
+        assert score.score == 0.0
+        assert "SyntaxError" in score.details
+
+    def test_well_documented_code(self):
+        scorer = DocumentationScorer(use_llm=False)
+        code = '''\
+"""User management module."""
+
+class UserService:
+    """Handles user operations."""
+
+    def get_user(self, user_id: int):
+        """Fetch a user by ID."""
+        # Look up in database
+        return self.db.find(user_id)
+
+    def create_user(self, name: str):
+        """Create a new user."""
+        # Validate input first
+        if not name:
+            raise ValueError("Name required")
+        return self.db.insert(name)
+'''
+        score = scorer.score(code, "users.py")
+        assert score.score > 0.8
+
+    def test_poorly_documented_code(self):
+        scorer = DocumentationScorer(use_llm=False)
+        code = """\
+class Foo:
+    def bar(self):
+        return 1
+
+    def baz(self, x):
+        if x > 0:
+            return x * 2
+        return 0
+
+def process(data):
+    result = []
+    for item in data:
+        if item.valid:
+            result.append(item.value)
+    return result
+"""
+        score = scorer.score(code, "messy.py")
+        assert score.score < 0.5
+
+    def test_deterministic(self):
+        scorer = DocumentationScorer(use_llm=False)
+        code = "def foo():\n    return 1"
+        s1 = scorer.score(code, "t.py")
+        clear_cache()
+        s2 = scorer.score(code, "t.py")
+        assert s1.score == s2.score


### PR DESCRIPTION
## Summary
- Implements `DocumentationScorer` with dual evaluation: LLM judge (Claude API) and rule-based fallback
- LLM judge evaluates: logic explanation (0.35), function docs (0.25), purpose docs (0.25), comment accuracy (0.15)
- Fallback checks: module docstrings, function/class docstrings, comment density
- Content-hash caching prevents redundant API calls
- Adds `anthropic` as optional dependency (`pip install rubric-gates[llm]`)

## Test plan
- [x] 34 tests with mock-based LLM testing (no real API calls)
- [x] Tests for fallback mode, caching, empty/syntax-error handling
- [x] All 279 tests in the full suite pass
- [x] Ruff lint and format clean

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)