### PR TITLE
feat: P1 composite scorer engine and CLI

### DIFF
--- a/scorecard/__main__.py
+++ b/scorecard/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running scorecard as: python -m scorecard path/to/file.py"""
+
+from scorecard.score import main
+
+main()

--- a/scorecard/engine.py
+++ b/scorecard/engine.py
@@ -1,0 +1,205 @@
+"""Composite scorer and rubric engine.
+
+Orchestrates all 5 dimension scorers, computes weighted composite score,
+and returns a complete ScoreResult. Main entry point for downstream
+consumers (hooks, CLI, dashboard).
+"""
+
+from __future__ import annotations
+
+import getpass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from scorecard.dimensions.correctness import CorrectnessScorer
+from scorecard.dimensions.documentation import DocumentationScorer
+from scorecard.dimensions.maintainability import MaintainabilityScorer
+from scorecard.dimensions.security import SecurityScorer
+from scorecard.dimensions.testability import TestabilityScorer
+from shared.config import RubricGatesConfig, load_config
+from shared.models import Dimension, DimensionScore, ScoreResult, ScoringMethod
+
+
+class RubricEngine:
+    """Orchestrates dimension scorers and computes composite scores.
+
+    Loads scorers based on config (only enabled ones), runs them,
+    and produces a weighted composite ScoreResult.
+    """
+
+    def __init__(self, config: RubricGatesConfig | None = None):
+        if config is None:
+            config = load_config()
+        self.config = config
+        self.scorecard_config = config.scorecard
+        self._scorers = self._load_scorers()
+
+    def _load_scorers(self) -> dict[Dimension, Any]:
+        """Load enabled dimension scorers based on config."""
+        scorers: dict[Dimension, Any] = {}
+        dims = self.scorecard_config.dimensions
+
+        if dims.get("correctness") and dims["correctness"].enabled:
+            scorers[Dimension.CORRECTNESS] = CorrectnessScorer()
+
+        if dims.get("security") and dims["security"].enabled:
+            scorers[Dimension.SECURITY] = SecurityScorer()
+
+        if dims.get("maintainability") and dims["maintainability"].enabled:
+            scorers[Dimension.MAINTAINABILITY] = MaintainabilityScorer()
+
+        if dims.get("documentation") and dims["documentation"].enabled:
+            # Use LLM=False by default in engine — opt-in via config/context
+            scorers[Dimension.DOCUMENTATION] = DocumentationScorer(use_llm=False)
+
+        if dims.get("testability") and dims["testability"].enabled:
+            scorers[Dimension.TESTABILITY] = TestabilityScorer(use_llm=False)
+
+        return scorers
+
+    def _get_weight(self, dimension: Dimension) -> float:
+        """Get the configured weight for a dimension."""
+        dim_config = self.scorecard_config.dimensions.get(dimension.value)
+        if dim_config is None:
+            return 0.0
+        return dim_config.weight
+
+    def score(
+        self,
+        code: str,
+        filename: str = "",
+        *,
+        user: str = "",
+        skill_used: str = "",
+        project_files: list[str] | None = None,
+        test_code: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> ScoreResult:
+        """Run all enabled dimension scorers and return composite result.
+
+        Args:
+            code: Source code to score.
+            filename: Name of the file being scored.
+            user: User who generated the code.
+            skill_used: Claude Code skill used.
+            project_files: List of project files (for testability check).
+            test_code: Corresponding test code (for testability check).
+            metadata: Additional metadata to attach to the result.
+        """
+        if not user:
+            try:
+                user = getpass.getuser()
+            except Exception:
+                user = "unknown"
+
+        dimension_scores: list[DimensionScore] = []
+        scorer_errors: list[str] = []
+
+        for dimension, scorer in self._scorers.items():
+            try:
+                if dimension == Dimension.TESTABILITY:
+                    dim_score = scorer.score(
+                        code,
+                        filename,
+                        project_files=project_files,
+                        test_code=test_code,
+                    )
+                else:
+                    dim_score = scorer.score(code, filename)
+                dimension_scores.append(dim_score)
+            except Exception as e:
+                scorer_errors.append(f"{dimension.value}: {e}")
+                # Add a zero score for the failed dimension
+                dimension_scores.append(
+                    DimensionScore(
+                        dimension=dimension,
+                        score=0.0,
+                        method=ScoringMethod.RULE_BASED,
+                        details=f"Scorer error: {e}",
+                    )
+                )
+
+        # Compute weighted composite score
+        composite = self._compute_composite(dimension_scores)
+
+        result_metadata = metadata.copy() if metadata else {}
+        if scorer_errors:
+            result_metadata["scorer_errors"] = scorer_errors
+
+        return ScoreResult(
+            timestamp=datetime.now(),
+            user=user,
+            skill_used=skill_used,
+            files_touched=[filename] if filename else [],
+            dimension_scores=dimension_scores,
+            composite_score=composite,
+            metadata=result_metadata,
+        )
+
+    def _compute_composite(self, scores: list[DimensionScore]) -> float:
+        """Compute weighted composite score from dimension scores."""
+        total_weight = 0.0
+        weighted_sum = 0.0
+
+        for ds in scores:
+            weight = self._get_weight(ds.dimension)
+            weighted_sum += ds.score * weight
+            total_weight += weight
+
+        if total_weight == 0:
+            return 0.0
+        return min(max(weighted_sum / total_weight, 0.0), 1.0)
+
+    def score_file(
+        self,
+        file_path: str | Path,
+        *,
+        user: str = "",
+        skill_used: str = "",
+        project_files: list[str] | None = None,
+    ) -> ScoreResult:
+        """Score a file from disk.
+
+        Args:
+            file_path: Path to the Python file to score.
+            user: User who generated the code.
+            skill_used: Claude Code skill used.
+            project_files: List of project files for testability.
+        """
+        path = Path(file_path)
+        code = path.read_text()
+        return self.score(
+            code,
+            filename=path.name,
+            user=user,
+            skill_used=skill_used,
+            project_files=project_files,
+        )
+
+    def score_files(
+        self,
+        file_paths: list[str | Path],
+        *,
+        user: str = "",
+        skill_used: str = "",
+    ) -> list[ScoreResult]:
+        """Score multiple files.
+
+        Args:
+            file_paths: Paths to Python files.
+            user: User who generated the code.
+            skill_used: Claude Code skill used.
+        """
+        str_paths = [str(p) for p in file_paths]
+        results = []
+        for fp in file_paths:
+            results.append(
+                self.score_file(
+                    fp,
+                    user=user,
+                    skill_used=skill_used,
+                    project_files=str_paths,
+                )
+            )
+        return results

--- a/scorecard/score.py
+++ b/scorecard/score.py
@@ -1,0 +1,67 @@
+"""CLI entry point for scoring files.
+
+Usage:
+    python -m scorecard.score path/to/file.py [path/to/file2.py ...]
+"""
+
+import sys
+from pathlib import Path
+
+from scorecard.engine import RubricEngine
+
+
+def main() -> None:
+    """Score files from the command line."""
+    if len(sys.argv) < 2:
+        print("Usage: python -m scorecard.score <file.py> [file2.py ...]")
+        sys.exit(1)
+
+    file_paths = [Path(p) for p in sys.argv[1:]]
+
+    # Validate files exist
+    for fp in file_paths:
+        if not fp.exists():
+            print(f"Error: {fp} not found")
+            sys.exit(1)
+        if not fp.suffix == ".py":
+            print(f"Warning: {fp} is not a .py file, skipping")
+            file_paths.remove(fp)
+
+    if not file_paths:
+        print("No valid Python files to score.")
+        sys.exit(1)
+
+    engine = RubricEngine()
+    results = engine.score_files(file_paths)
+
+    for result in results:
+        _print_result(result)
+
+
+def _print_result(result) -> None:
+    """Pretty-print a ScoreResult."""
+    files = ", ".join(result.files_touched) or "(none)"
+    print(f"\n{'=' * 60}")
+    print(f"File: {files}")
+    print(f"Composite Score: {result.composite_score:.2f}")
+    print(f"User: {result.user}")
+    print(f"{'─' * 60}")
+
+    for ds in result.dimension_scores:
+        bar = "█" * int(ds.score * 20) + "░" * (20 - int(ds.score * 20))
+        print(f"  {ds.dimension.value:<18} {bar} {ds.score:.2f}  ({ds.method.value})")
+        if ds.details:
+            # Truncate long details
+            detail_text = ds.details[:100] + "..." if len(ds.details) > 100 else ds.details
+            print(f"    {detail_text}")
+
+    if result.metadata.get("scorer_errors"):
+        print("\n  Errors:")
+        for err in result.metadata["scorer_errors"]:
+            print(f"    ⚠ {err}")
+
+    print(f"{'=' * 60}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scorecard/test_engine.py
+++ b/tests/scorecard/test_engine.py
@@ -1,0 +1,307 @@
+"""Tests for the composite scorer and rubric engine."""
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from scorecard.engine import RubricEngine
+from shared.config import DimensionConfig, RubricGatesConfig, ScorecardConfig
+from shared.models import Dimension
+
+
+@pytest.fixture()
+def default_engine():
+    """Engine with default config (all dimensions enabled, LLM disabled)."""
+    return RubricEngine()
+
+
+@pytest.fixture()
+def custom_config():
+    """Config with specific weights and some dimensions disabled."""
+    return RubricGatesConfig(
+        scorecard=ScorecardConfig(
+            dimensions={
+                "correctness": DimensionConfig(weight=0.5, enabled=True),
+                "security": DimensionConfig(weight=0.3, enabled=True),
+                "maintainability": DimensionConfig(weight=0.2, enabled=True),
+                "documentation": DimensionConfig(weight=0.0, enabled=False),
+                "testability": DimensionConfig(weight=0.0, enabled=False),
+            }
+        )
+    )
+
+
+# --- Engine Initialization ---
+
+
+class TestEngineInit:
+    def test_default_loads_all_scorers(self, default_engine):
+        assert Dimension.CORRECTNESS in default_engine._scorers
+        assert Dimension.SECURITY in default_engine._scorers
+        assert Dimension.MAINTAINABILITY in default_engine._scorers
+        assert Dimension.DOCUMENTATION in default_engine._scorers
+        assert Dimension.TESTABILITY in default_engine._scorers
+
+    def test_disabled_dimensions_excluded(self, custom_config):
+        engine = RubricEngine(config=custom_config)
+        assert Dimension.CORRECTNESS in engine._scorers
+        assert Dimension.SECURITY in engine._scorers
+        assert Dimension.MAINTAINABILITY in engine._scorers
+        assert Dimension.DOCUMENTATION not in engine._scorers
+        assert Dimension.TESTABILITY not in engine._scorers
+
+    def test_loads_config_from_defaults(self):
+        engine = RubricEngine()
+        assert engine.config is not None
+        assert engine.scorecard_config is not None
+
+
+# --- Scoring ---
+
+
+class TestScoring:
+    def test_score_clean_code(self, default_engine):
+        code = """\
+\"\"\"Math utilities.\"\"\"
+
+
+def add(a: int, b: int) -> int:
+    \"\"\"Add two numbers.\"\"\"
+    return a + b
+
+
+def multiply(a: int, b: int) -> int:
+    \"\"\"Multiply two numbers.\"\"\"
+    return a * b
+"""
+        result = default_engine.score(code, "math_utils.py", user="alice")
+
+        assert result.user == "alice"
+        assert result.files_touched == ["math_utils.py"]
+        assert 0.0 <= result.composite_score <= 1.0
+        assert len(result.dimension_scores) == 5  # All 5 scorers
+        assert result.composite_score > 0.5  # Clean code should score well
+
+    def test_score_bad_code(self, default_engine):
+        code = "def broken( return"
+        result = default_engine.score(code, "bad.py", user="bob")
+
+        assert result.composite_score < 0.5
+        assert result.user == "bob"
+
+    def test_score_empty_code(self, default_engine):
+        result = default_engine.score("", "empty.py", user="test")
+        assert result.composite_score == 0.0
+
+    def test_score_with_metadata(self, default_engine):
+        code = "x = 1"
+        result = default_engine.score(
+            code,
+            "test.py",
+            user="alice",
+            metadata={"session_id": "abc123"},
+        )
+        assert result.metadata["session_id"] == "abc123"
+
+    def test_score_with_skill(self, default_engine):
+        code = "x = 1"
+        result = default_engine.score(
+            code,
+            "test.py",
+            user="alice",
+            skill_used="scaffold-api",
+        )
+        assert result.skill_used == "scaffold-api"
+
+    def test_score_auto_user(self, default_engine):
+        code = "x = 1"
+        result = default_engine.score(code, "test.py")
+        assert result.user != ""  # Should auto-detect
+
+    def test_score_no_filename(self, default_engine):
+        code = "x = 1\nprint(x)"
+        result = default_engine.score(code, user="test")
+        assert result.files_touched == []
+        assert result.composite_score > 0.0
+
+
+# --- Composite Score Calculation ---
+
+
+class TestCompositeScore:
+    def test_weights_are_applied(self, custom_config):
+        engine = RubricEngine(config=custom_config)
+        code = """\
+def add(a: int, b: int) -> int:
+    return a + b
+"""
+        result = engine.score(code, "utils.py", user="test")
+
+        # Should only have 3 dimension scores (doc + test disabled)
+        assert len(result.dimension_scores) == 3
+        dims = {ds.dimension for ds in result.dimension_scores}
+        assert Dimension.CORRECTNESS in dims
+        assert Dimension.SECURITY in dims
+        assert Dimension.MAINTAINABILITY in dims
+
+    def test_all_perfect_scores_give_1(self, custom_config):
+        engine = RubricEngine(config=custom_config)
+        # Simple, clean code should score near 1.0 for rule-based scorers
+        code = """\
+def add(a: int, b: int) -> int:
+    return a + b
+"""
+        result = engine.score(code, "utils.py", user="test")
+        # Correctness + security + maintainability should all be high
+        for ds in result.dimension_scores:
+            assert ds.score >= 0.8, f"{ds.dimension.value} scored {ds.score}"
+
+    def test_composite_between_0_and_1(self, default_engine):
+        code = "x = 1\nprint(x)"
+        result = default_engine.score(code, "test.py", user="test")
+        assert 0.0 <= result.composite_score <= 1.0
+
+
+# --- Error Handling ---
+
+
+class TestErrorHandling:
+    def test_scorer_failure_graceful(self, default_engine):
+        """If a scorer raises, the engine should still return a result."""
+        code = "x = 1"
+
+        with patch.object(
+            default_engine._scorers[Dimension.CORRECTNESS],
+            "score",
+            side_effect=RuntimeError("scorer broke"),
+        ):
+            result = default_engine.score(code, "test.py", user="test")
+
+        assert result.composite_score >= 0.0
+        # Should have a zero-score entry for correctness
+        correctness = next(
+            ds for ds in result.dimension_scores if ds.dimension == Dimension.CORRECTNESS
+        )
+        assert correctness.score == 0.0
+        assert "Scorer error" in correctness.details
+        assert "scorer_errors" in result.metadata
+
+    def test_all_scorers_fail(self, default_engine):
+        """If all scorers fail, composite should be 0.0."""
+        code = "x = 1"
+
+        for scorer in default_engine._scorers.values():
+            with patch.object(scorer, "score", side_effect=RuntimeError("broken")):
+                pass
+
+        # Patch all at once
+        patches = []
+        for scorer in default_engine._scorers.values():
+            p = patch.object(scorer, "score", side_effect=RuntimeError("broken"))
+            patches.append(p)
+
+        for p in patches:
+            p.start()
+        try:
+            result = default_engine.score(code, "test.py", user="test")
+            assert result.composite_score == 0.0
+            assert len(result.metadata["scorer_errors"]) == 5
+        finally:
+            for p in patches:
+                p.stop()
+
+
+# --- File Scoring ---
+
+
+class TestFileScoring:
+    def test_score_file(self, default_engine, tmp_path):
+        f = tmp_path / "utils.py"
+        f.write_text("def add(a, b):\n    return a + b\n")
+
+        result = default_engine.score_file(f, user="alice")
+        assert result.files_touched == ["utils.py"]
+        assert result.composite_score > 0.0
+
+    def test_score_files(self, default_engine, tmp_path):
+        f1 = tmp_path / "a.py"
+        f2 = tmp_path / "b.py"
+        f1.write_text("x = 1\n")
+        f2.write_text("y = 2\n")
+
+        results = default_engine.score_files([f1, f2], user="alice")
+        assert len(results) == 2
+        assert results[0].files_touched == ["a.py"]
+        assert results[1].files_touched == ["b.py"]
+
+    def test_score_files_passes_project_files(self, default_engine, tmp_path):
+        code_file = tmp_path / "utils.py"
+        test_file = tmp_path / "test_utils.py"
+        code_file.write_text("def add(a, b):\n    return a + b\n")
+        test_file.write_text("def test_add():\n    assert add(1, 2) == 3\n")
+
+        results = default_engine.score_files([code_file, test_file], user="test")
+        assert len(results) == 2
+
+
+# --- Performance ---
+
+
+class TestPerformance:
+    def test_rule_based_under_100ms(self, default_engine):
+        """Rule-based scorers should complete quickly."""
+        code = """\
+import os
+from pathlib import Path
+
+def process(filename: str) -> str:
+    path = Path(filename)
+    if not path.exists():
+        return ""
+    with open(path) as f:
+        return f.read()
+
+class FileHandler:
+    def __init__(self, base_dir: str):
+        self.base_dir = Path(base_dir)
+
+    def list_files(self) -> list[str]:
+        return [f.name for f in self.base_dir.iterdir()]
+"""
+        start = time.perf_counter()
+        result = default_engine.score(code, "handler.py", user="test")
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        assert result.composite_score > 0.0
+        assert elapsed_ms < 100, f"Scoring took {elapsed_ms:.1f}ms (should be <100ms)"
+
+
+# --- Dimension Coverage ---
+
+
+class TestDimensionCoverage:
+    def test_all_dimensions_scored(self, default_engine):
+        code = "def foo():\n    return 1"
+        result = default_engine.score(code, "test.py", user="test")
+
+        scored_dims = {ds.dimension for ds in result.dimension_scores}
+        assert Dimension.CORRECTNESS in scored_dims
+        assert Dimension.SECURITY in scored_dims
+        assert Dimension.MAINTAINABILITY in scored_dims
+        assert Dimension.DOCUMENTATION in scored_dims
+        assert Dimension.TESTABILITY in scored_dims
+
+    def test_each_dimension_has_details(self, default_engine):
+        code = "def foo():\n    return 1"
+        result = default_engine.score(code, "test.py", user="test")
+
+        for ds in result.dimension_scores:
+            assert ds.details != "", f"{ds.dimension.value} has empty details"
+
+    def test_each_dimension_has_method(self, default_engine):
+        code = "def foo():\n    return 1"
+        result = default_engine.score(code, "test.py", user="test")
+
+        for ds in result.dimension_scores:
+            assert ds.method is not None


### PR DESCRIPTION
## Summary
- Implements `RubricEngine` orchestrator that runs all 5 dimension scorers and computes weighted composite score
- Config-driven: loads only enabled scorers, respects configured weights
- Graceful error handling: failed scorers produce zero-score entries with error metadata
- CLI entry point: `python -m scorecard.score path/to/file.py`
- `score()`, `score_file()`, and `score_files()` APIs for different consumers

## Test plan
- [x] 22 tests covering engine init, scoring, composite calculation, error handling, file scoring, performance
- [x] Performance test: rule-based scorers complete in <100ms per file
- [x] All 334 tests in the full suite pass
- [x] Ruff lint and format clean

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)