### PR TITLE
feat: P1 Claude Code post-edit hook integration

### DIFF
--- a/scorecard/hooks/post_edit.py
+++ b/scorecard/hooks/post_edit.py
@@ -1,0 +1,233 @@
+"""Post-edit hook for Claude Code integration.
+
+Scores files after Write/Edit tool use. Two modes:
+- Quick mode (default): rule-based only, instant feedback (<100ms)
+- Full mode (--full): includes LLM scorers, runs async
+
+Usage:
+    # Quick score (non-blocking)
+    python -m scorecard.hooks.post_edit --file path/to/file.py
+
+    # Full score (async, logs to storage)
+    python -m scorecard.hooks.post_edit --file path/to/file.py --full
+
+    # Quiet mode (no output, just log)
+    python -m scorecard.hooks.post_edit --file path/to/file.py --quiet
+
+    # Specify user/skill
+    python -m scorecard.hooks.post_edit --file path/to/file.py --user alice --skill scaffold-api
+"""
+
+from __future__ import annotations
+
+import argparse
+import multiprocessing
+import sys
+from pathlib import Path
+
+from scorecard.engine import RubricEngine
+from shared.config import DimensionConfig, RubricGatesConfig, load_config
+from shared.models import Dimension, ScoreResult
+from shared.storage import create_storage
+
+
+def _build_quick_config(base_config: RubricGatesConfig) -> RubricGatesConfig:
+    """Build a config that disables LLM-based scorers for quick mode."""
+    quick_dims = {}
+    for name, dim_config in base_config.scorecard.dimensions.items():
+        if name in ("documentation", "testability"):
+            # Keep enabled but engine uses use_llm=False by default
+            quick_dims[name] = DimensionConfig(
+                weight=dim_config.weight,
+                enabled=dim_config.enabled,
+            )
+        else:
+            quick_dims[name] = dim_config.model_copy()
+    config_data = base_config.model_dump()
+    config_data["scorecard"]["dimensions"] = {k: v.model_dump() for k, v in quick_dims.items()}
+    return RubricGatesConfig.model_validate(config_data)
+
+
+def format_score_line(result: ScoreResult) -> str:
+    """Format a one-line score summary.
+
+    Example: "Score: 0.82 [C:0.9 S:0.8 M:0.7 D:0.8 T:0.9]"
+    """
+    dim_abbrev = {
+        Dimension.CORRECTNESS: "C",
+        Dimension.SECURITY: "S",
+        Dimension.MAINTAINABILITY: "M",
+        Dimension.DOCUMENTATION: "D",
+        Dimension.TESTABILITY: "T",
+    }
+    parts = []
+    for ds in result.dimension_scores:
+        abbr = dim_abbrev.get(ds.dimension, ds.dimension.value[0].upper())
+        parts.append(f"{abbr}:{ds.score:.1f}")
+    dim_str = " ".join(parts)
+    return f"Score: {result.composite_score:.2f} [{dim_str}]"
+
+
+def run_scoring(
+    file_path: str,
+    *,
+    user: str = "",
+    skill_used: str = "",
+    full: bool = False,
+    quiet: bool = False,
+    store: bool = True,
+) -> ScoreResult | None:
+    """Score a file and optionally store + print results.
+
+    Args:
+        file_path: Path to the Python file to score.
+        user: User who generated the code.
+        skill_used: Claude Code skill used.
+        full: If True, include LLM-based scorers.
+        quiet: If True, suppress output.
+        store: If True, append result to storage.
+
+    Returns:
+        ScoreResult or None if the file can't be scored.
+    """
+    path = Path(file_path)
+    if not path.exists():
+        if not quiet:
+            print(f"rubric-gates: file not found: {path}", file=sys.stderr)
+        return None
+
+    if not path.suffix == ".py":
+        # Only score Python files
+        return None
+
+    try:
+        code = path.read_text()
+    except Exception as e:
+        if not quiet:
+            print(f"rubric-gates: read error: {e}", file=sys.stderr)
+        return None
+
+    if not code.strip():
+        return None
+
+    # Load config and build engine
+    try:
+        config = load_config()
+        if not full:
+            config = _build_quick_config(config)
+        engine = RubricEngine(config=config)
+    except Exception as e:
+        if not quiet:
+            print(f"rubric-gates: config error: {e}", file=sys.stderr)
+        return None
+
+    # Score
+    try:
+        result = engine.score(
+            code,
+            filename=path.name,
+            user=user,
+            skill_used=skill_used,
+        )
+    except Exception as e:
+        if not quiet:
+            print(f"rubric-gates: scoring error: {e}", file=sys.stderr)
+        return None
+
+    # Store
+    if store:
+        try:
+            storage = create_storage()
+            storage.append(result)
+        except Exception as e:
+            if not quiet:
+                print(f"rubric-gates: storage error: {e}", file=sys.stderr)
+
+    # Output
+    if not quiet:
+        print(f"rubric-gates: {format_score_line(result)}", file=sys.stderr)
+
+    return result
+
+
+def _run_full_async(file_path: str, user: str, skill_used: str) -> None:
+    """Run full scoring in a background process."""
+    run_scoring(
+        file_path,
+        user=user,
+        skill_used=skill_used,
+        full=True,
+        quiet=True,
+        store=True,
+    )
+
+
+def main() -> None:
+    """CLI entry point for the post-edit hook."""
+    parser = argparse.ArgumentParser(
+        description="Rubric-gates post-edit hook: score a file after edit",
+    )
+    parser.add_argument(
+        "--file",
+        required=True,
+        help="Path to the file to score",
+    )
+    parser.add_argument(
+        "--user",
+        default="",
+        help="User who generated the code",
+    )
+    parser.add_argument(
+        "--skill",
+        default="",
+        help="Claude Code skill used",
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Run full scoring including LLM judges (slower)",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress output (just store results)",
+    )
+    parser.add_argument(
+        "--async",
+        dest="run_async",
+        action="store_true",
+        help="Run full scoring in background process",
+    )
+    parser.add_argument(
+        "--no-store",
+        action="store_true",
+        help="Don't store results (dry run)",
+    )
+
+    args = parser.parse_args()
+
+    # Quick score (always runs synchronously for instant feedback)
+    result = run_scoring(
+        args.file,
+        user=args.user,
+        skill_used=args.skill,
+        full=args.full and not args.run_async,
+        quiet=args.quiet,
+        store=not args.no_store,
+    )
+
+    # If --async, also kick off full scoring in background
+    if args.run_async and result is not None:
+        proc = multiprocessing.Process(
+            target=_run_full_async,
+            args=(args.file, args.user, args.skill),
+            daemon=True,
+        )
+        proc.start()
+        # Don't wait — let it run in background
+
+    sys.exit(0 if result is not None else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scorecard/test_hook.py
+++ b/tests/scorecard/test_hook.py
@@ -1,0 +1,209 @@
+"""Tests for Claude Code post-edit hook."""
+
+from unittest.mock import MagicMock, patch
+
+from scorecard.hooks.post_edit import format_score_line, run_scoring
+from shared.models import Dimension, DimensionScore, ScoreResult, ScoringMethod
+
+
+# --- format_score_line ---
+
+
+class TestFormatScoreLine:
+    def test_basic_format(self):
+        result = ScoreResult(
+            user="alice",
+            composite_score=0.82,
+            dimension_scores=[
+                DimensionScore(
+                    dimension=Dimension.CORRECTNESS, score=0.9, method=ScoringMethod.AST_PARSE
+                ),
+                DimensionScore(
+                    dimension=Dimension.SECURITY, score=0.8, method=ScoringMethod.RULE_BASED
+                ),
+                DimensionScore(
+                    dimension=Dimension.MAINTAINABILITY, score=0.7, method=ScoringMethod.RULE_BASED
+                ),
+                DimensionScore(
+                    dimension=Dimension.DOCUMENTATION, score=0.8, method=ScoringMethod.RULE_BASED
+                ),
+                DimensionScore(
+                    dimension=Dimension.TESTABILITY, score=0.9, method=ScoringMethod.RULE_BASED
+                ),
+            ],
+        )
+        line = format_score_line(result)
+        assert "Score: 0.82" in line
+        assert "C:0.9" in line
+        assert "S:0.8" in line
+        assert "M:0.7" in line
+        assert "D:0.8" in line
+        assert "T:0.9" in line
+        assert "[" in line and "]" in line
+
+    def test_empty_dimensions(self):
+        result = ScoreResult(user="alice", composite_score=0.0)
+        line = format_score_line(result)
+        assert "Score: 0.00" in line
+
+    def test_single_dimension(self):
+        result = ScoreResult(
+            user="alice",
+            composite_score=0.5,
+            dimension_scores=[
+                DimensionScore(
+                    dimension=Dimension.CORRECTNESS, score=0.5, method=ScoringMethod.AST_PARSE
+                ),
+            ],
+        )
+        line = format_score_line(result)
+        assert "C:0.5" in line
+
+
+# --- run_scoring ---
+
+
+class TestRunScoring:
+    def test_score_python_file(self, tmp_path):
+        f = tmp_path / "utils.py"
+        f.write_text("def add(a, b):\n    return a + b\n")
+
+        result = run_scoring(str(f), user="test", quiet=True, store=False)
+        assert result is not None
+        assert result.composite_score > 0.0
+        assert result.user == "test"
+
+    def test_nonexistent_file(self):
+        result = run_scoring("/nonexistent/file.py", quiet=True, store=False)
+        assert result is None
+
+    def test_non_python_file(self, tmp_path):
+        f = tmp_path / "readme.md"
+        f.write_text("# Hello")
+        result = run_scoring(str(f), quiet=True, store=False)
+        assert result is None
+
+    def test_empty_file(self, tmp_path):
+        f = tmp_path / "empty.py"
+        f.write_text("")
+        result = run_scoring(str(f), quiet=True, store=False)
+        assert result is None
+
+    def test_whitespace_only_file(self, tmp_path):
+        f = tmp_path / "blank.py"
+        f.write_text("   \n\n  ")
+        result = run_scoring(str(f), quiet=True, store=False)
+        assert result is None
+
+    def test_output_to_stderr(self, tmp_path, capsys):
+        f = tmp_path / "test.py"
+        f.write_text("x = 1\n")
+
+        run_scoring(str(f), user="test", quiet=False, store=False)
+        captured = capsys.readouterr()
+        assert "rubric-gates: Score:" in captured.err
+
+    def test_quiet_suppresses_output(self, tmp_path, capsys):
+        f = tmp_path / "test.py"
+        f.write_text("x = 1\n")
+
+        run_scoring(str(f), user="test", quiet=True, store=False)
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_stores_result(self, tmp_path):
+        f = tmp_path / "test.py"
+        f.write_text("x = 1\n")
+
+        with patch("scorecard.hooks.post_edit.create_storage") as mock_storage:
+            mock_backend = MagicMock()
+            mock_storage.return_value = mock_backend
+
+            run_scoring(str(f), user="test", quiet=True, store=True)
+            mock_backend.append.assert_called_once()
+
+    def test_no_store_skips_storage(self, tmp_path):
+        f = tmp_path / "test.py"
+        f.write_text("x = 1\n")
+
+        with patch("scorecard.hooks.post_edit.create_storage") as mock_storage:
+            run_scoring(str(f), user="test", quiet=True, store=False)
+            mock_storage.assert_not_called()
+
+    def test_storage_failure_graceful(self, tmp_path, capsys):
+        f = tmp_path / "test.py"
+        f.write_text("x = 1\n")
+
+        with patch("scorecard.hooks.post_edit.create_storage") as mock_storage:
+            mock_storage.side_effect = RuntimeError("storage broken")
+
+            result = run_scoring(str(f), user="test", quiet=False, store=True)
+            # Should still return a result despite storage failure
+            assert result is not None
+            captured = capsys.readouterr()
+            assert "storage error" in captured.err
+
+    def test_skill_passed_through(self, tmp_path):
+        f = tmp_path / "test.py"
+        f.write_text("x = 1\n")
+
+        result = run_scoring(
+            str(f),
+            user="alice",
+            skill_used="scaffold-api",
+            quiet=True,
+            store=False,
+        )
+        assert result is not None
+        assert result.skill_used == "scaffold-api"
+
+    def test_full_mode(self, tmp_path):
+        f = tmp_path / "test.py"
+        f.write_text("def foo():\n    return 1\n")
+
+        result = run_scoring(str(f), user="test", full=True, quiet=True, store=False)
+        assert result is not None
+        assert result.composite_score > 0.0
+
+    def test_scoring_error_graceful(self, tmp_path, capsys):
+        f = tmp_path / "test.py"
+        f.write_text("x = 1\n")
+
+        with patch("scorecard.hooks.post_edit.RubricEngine") as mock_engine_cls:
+            mock_engine = MagicMock()
+            mock_engine.score.side_effect = RuntimeError("engine broke")
+            mock_engine_cls.return_value = mock_engine
+
+            result = run_scoring(str(f), user="test", quiet=False, store=False)
+            assert result is None
+            captured = capsys.readouterr()
+            assert "scoring error" in captured.err
+
+
+# --- Quick mode config ---
+
+
+class TestQuickMode:
+    def test_quick_mode_is_default(self, tmp_path):
+        """Quick mode (no --full) should still score all dimensions."""
+        f = tmp_path / "test.py"
+        f.write_text("def foo():\n    return 1\n")
+
+        result = run_scoring(str(f), user="test", full=False, quiet=True, store=False)
+        assert result is not None
+        dims = {ds.dimension for ds in result.dimension_scores}
+        assert Dimension.CORRECTNESS in dims
+        assert Dimension.SECURITY in dims
+
+    def test_quick_mode_fast(self, tmp_path):
+        """Quick mode should be fast (<100ms)."""
+        import time
+
+        f = tmp_path / "test.py"
+        f.write_text("def foo():\n    return 1\n")
+
+        start = time.perf_counter()
+        run_scoring(str(f), user="test", full=False, quiet=True, store=False)
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        assert elapsed_ms < 200  # Allow some margin for test overhead


### PR DESCRIPTION
## Summary
- Implements `post_tool_use` hook for automatic scoring after Write/Edit
- **Quick mode** (default): rule-based scorers only, <100ms feedback
- **Full mode** (`--full`): includes LLM judges for comprehensive evaluation
- **Async mode** (`--async`): quick feedback + background full scoring via `multiprocessing`
- Concise stderr output: `Score: 0.82 [C:0.9 S:0.8 M:0.7 D:0.8 T:0.9]`
- Stores results to JSONL backend; graceful failure on storage/scoring errors

### Claude Code hook config
```json
{
  "hooks": {
    "post_tool_use": [{
      "matcher": "Write|Edit",
      "command": "python -m scorecard.hooks.post_edit --file $FILE_PATH"
    }]
  }
}
```

## Test plan
- [x] 18 tests covering scoring, output formatting, storage, error handling, performance
- [x] All 352 tests in the full suite pass
- [x] Ruff lint and format clean

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)