### PR TITLE
feat(p2): override workflow with audit logging and rate limiting

### DIFF
--- a/gate/overrides/manager.py
+++ b/gate/overrides/manager.py
@@ -1,0 +1,281 @@
+"""Override workflow manager with audit logging.
+
+Handles override requests when code hits red tier, tracks audit records,
+enforces rate limits, and manages escalation workflow.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import uuid
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from shared.config import OverridesConfig, load_config
+from shared.models import GateResult, OverrideRecord
+
+
+class OverrideResult:
+    """Result of an override request."""
+
+    def __init__(
+        self,
+        approved: bool,
+        record: OverrideRecord | None = None,
+        reason: str = "",
+    ) -> None:
+        self.approved = approved
+        self.record = record
+        self.reason = reason
+
+
+class OverrideManager:
+    """Manages gate override requests with audit logging and rate limiting.
+
+    Args:
+        config: Overrides configuration. Uses defaults if not provided.
+        storage_path: Path to store override audit logs.
+    """
+
+    def __init__(
+        self,
+        config: OverridesConfig | None = None,
+        storage_path: str | Path | None = None,
+    ) -> None:
+        if config is None:
+            config = load_config().gate.overrides
+        self.config = config
+
+        if storage_path is None:
+            storage_path = Path("./rubric-gates-data/overrides")
+        self.storage_path = Path(storage_path)
+        self.storage_path.mkdir(parents=True, exist_ok=True)
+
+    def _log_file(self) -> Path:
+        """Get the override audit log file path."""
+        return self.storage_path / "overrides.jsonl"
+
+    def _append_record(self, record: OverrideRecord) -> None:
+        """Append an override record to the audit log."""
+        target = self._log_file()
+        line = record.model_dump_json() + "\n"
+        with open(target, "a") as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            try:
+                f.write(line)
+            finally:
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+    def _read_all_records(self) -> list[OverrideRecord]:
+        """Read all override records from the audit log."""
+        target = self._log_file()
+        if not target.exists():
+            return []
+
+        records: list[OverrideRecord] = []
+        with open(target) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(OverrideRecord.model_validate_json(line))
+                except Exception:
+                    continue
+        return records
+
+    def _update_record(self, record_id: str, **updates: str) -> bool:
+        """Update a record in the audit log by rewriting the file."""
+        target = self._log_file()
+        if not target.exists():
+            return False
+
+        records = self._read_all_records()
+        found = False
+        updated_records: list[OverrideRecord] = []
+
+        for rec in records:
+            if rec.id == record_id:
+                for key, val in updates.items():
+                    setattr(rec, key, val)
+                found = True
+            updated_records.append(rec)
+
+        if not found:
+            return False
+
+        # Rewrite file
+        with open(target, "w") as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            try:
+                for rec in updated_records:
+                    f.write(rec.model_dump_json() + "\n")
+            finally:
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+        return True
+
+    def _count_user_overrides_this_week(self, user: str) -> int:
+        """Count how many overrides a user has made in the current week."""
+        week_start = datetime.now() - timedelta(days=7)
+        records = self._read_all_records()
+        return sum(
+            1
+            for r in records
+            if r.user == user and r.override_type == "proceed" and r.timestamp >= week_start
+        )
+
+    def request_override(
+        self,
+        gate_result: GateResult,
+        user: str,
+        justification: str,
+        filename: str = "",
+    ) -> OverrideResult:
+        """Process an override request.
+
+        Args:
+            gate_result: The gate result that was blocked.
+            user: The user requesting the override.
+            justification: Reason for the override.
+            filename: The file being overridden.
+
+        Returns:
+            OverrideResult with approved status and audit record.
+        """
+        # Check justification requirement
+        if self.config.require_justification and not justification.strip():
+            return OverrideResult(
+                approved=False,
+                reason="Justification is required for overrides.",
+            )
+
+        # Check rate limit
+        weekly_count = self._count_user_overrides_this_week(user)
+        if weekly_count >= self.config.max_overrides_per_user_per_week:
+            return OverrideResult(
+                approved=False,
+                reason=(
+                    f"Override limit reached ({weekly_count}/"
+                    f"{self.config.max_overrides_per_user_per_week} this week). "
+                    "Please escalate to the tech team instead."
+                ),
+            )
+
+        # Create override record
+        record = OverrideRecord(
+            id=str(uuid.uuid4()),
+            user=user,
+            filename=filename,
+            gate_result=gate_result,
+            justification=justification,
+            override_type="proceed",
+            review_outcome="pending",
+        )
+
+        # Store audit record
+        self._append_record(record)
+
+        return OverrideResult(
+            approved=True,
+            record=record,
+            reason="Override approved. Audit record created.",
+        )
+
+    def request_escalation(
+        self,
+        gate_result: GateResult,
+        user: str,
+        justification: str,
+        filename: str = "",
+    ) -> OverrideResult:
+        """Escalate to tech team for review.
+
+        Args:
+            gate_result: The gate result that was blocked.
+            user: The user requesting escalation.
+            justification: Reason for the escalation.
+            filename: The file being escalated.
+
+        Returns:
+            OverrideResult with the escalation record.
+        """
+        record = OverrideRecord(
+            id=str(uuid.uuid4()),
+            user=user,
+            filename=filename,
+            gate_result=gate_result,
+            justification=justification,
+            override_type="escalate",
+            review_outcome="pending",
+        )
+
+        self._append_record(record)
+
+        return OverrideResult(
+            approved=False,
+            record=record,
+            reason="Escalated to tech team. Awaiting review.",
+        )
+
+    def get_pending_escalations(self) -> list[OverrideRecord]:
+        """Get all escalations awaiting tech team review."""
+        records = self._read_all_records()
+        return [
+            r for r in records if r.override_type == "escalate" and r.review_outcome == "pending"
+        ]
+
+    def get_user_overrides(self, user: str, since: datetime | None = None) -> list[OverrideRecord]:
+        """Get all overrides for a specific user."""
+        records = self._read_all_records()
+        return [r for r in records if r.user == user and (since is None or r.timestamp >= since)]
+
+    def resolve_escalation(
+        self,
+        override_id: str,
+        reviewer: str,
+        outcome: str,
+    ) -> bool:
+        """Tech team resolves an escalation.
+
+        Args:
+            override_id: The ID of the override record.
+            reviewer: The tech team member resolving.
+            outcome: "approved" or "rejected".
+
+        Returns:
+            True if the record was found and updated.
+        """
+        if outcome not in ("approved", "rejected"):
+            return False
+
+        return self._update_record(
+            override_id,
+            reviewed_by=reviewer,
+            review_outcome=outcome,
+        )
+
+    def get_override_stats(self, user: str) -> dict:
+        """Get override statistics for a user."""
+        records = self._read_all_records()
+        user_records = [r for r in records if r.user == user]
+        week_start = datetime.now() - timedelta(days=7)
+        weekly = [r for r in user_records if r.timestamp >= week_start]
+
+        return {
+            "total_overrides": len(user_records),
+            "weekly_overrides": len([r for r in weekly if r.override_type == "proceed"]),
+            "weekly_limit": self.config.max_overrides_per_user_per_week,
+            "remaining_this_week": max(
+                0,
+                self.config.max_overrides_per_user_per_week
+                - len([r for r in weekly if r.override_type == "proceed"]),
+            ),
+            "pending_escalations": len(
+                [
+                    r
+                    for r in user_records
+                    if r.override_type == "escalate" and r.review_outcome == "pending"
+                ]
+            ),
+        }

--- a/shared/models.py
+++ b/shared/models.py
@@ -100,6 +100,20 @@ class GateResult(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 
+class OverrideRecord(BaseModel):
+    """Audit record for a gate override."""
+
+    id: str = ""
+    timestamp: datetime = Field(default_factory=datetime.now)
+    user: str
+    filename: str = ""
+    gate_result: GateResult
+    justification: str = ""
+    override_type: str = "proceed"  # "proceed" | "escalate"
+    reviewed_by: str = ""
+    review_outcome: str = "pending"  # "approved" | "rejected" | "pending"
+
+
 # --- Registry Models ---
 
 

--- a/tests/gate/test_overrides.py
+++ b/tests/gate/test_overrides.py
@@ -1,0 +1,255 @@
+"""Tests for the override workflow manager."""
+
+from shared.config import OverridesConfig
+from shared.models import (
+    GateResult,
+    GateTier,
+    ScoreResult,
+)
+
+from gate.overrides.manager import OverrideManager
+
+
+def _make_gate_result(blocked: bool = True) -> GateResult:
+    return GateResult(
+        tier=GateTier.RED,
+        score_result=ScoreResult(user="test", composite_score=0.3),
+        blocked=blocked,
+        critical_patterns_found=["hardcoded_credentials"],
+        advisory_messages=["BLOCKED: Hardcoded password found."],
+    )
+
+
+# --- Override requests ---
+
+
+class TestOverrideRequest:
+    def test_basic_override(self, tmp_path):
+        mgr = OverrideManager(storage_path=tmp_path / "overrides")
+        gate = _make_gate_result()
+        result = mgr.request_override(
+            gate, user="alice", justification="False positive, this is a test fixture."
+        )
+        assert result.approved
+        assert result.record is not None
+        assert result.record.user == "alice"
+        assert result.record.override_type == "proceed"
+        assert result.record.justification == "False positive, this is a test fixture."
+
+    def test_override_creates_audit_record(self, tmp_path):
+        mgr = OverrideManager(storage_path=tmp_path / "overrides")
+        gate = _make_gate_result()
+        mgr.request_override(gate, user="alice", justification="test reason")
+
+        records = mgr._read_all_records()
+        assert len(records) == 1
+        assert records[0].user == "alice"
+        assert records[0].id != ""
+
+    def test_override_with_filename(self, tmp_path):
+        mgr = OverrideManager(storage_path=tmp_path / "overrides")
+        gate = _make_gate_result()
+        result = mgr.request_override(
+            gate, user="alice", justification="test", filename="config.py"
+        )
+        assert result.record.filename == "config.py"
+
+
+# --- Justification required ---
+
+
+class TestJustificationRequired:
+    def test_empty_justification_denied(self, tmp_path):
+        config = OverridesConfig(require_justification=True)
+        mgr = OverrideManager(config=config, storage_path=tmp_path / "overrides")
+        gate = _make_gate_result()
+        result = mgr.request_override(gate, user="alice", justification="")
+        assert not result.approved
+        assert "justification" in result.reason.lower()
+
+    def test_whitespace_justification_denied(self, tmp_path):
+        config = OverridesConfig(require_justification=True)
+        mgr = OverrideManager(config=config, storage_path=tmp_path / "overrides")
+        gate = _make_gate_result()
+        result = mgr.request_override(gate, user="alice", justification="   ")
+        assert not result.approved
+
+    def test_justification_not_required(self, tmp_path):
+        config = OverridesConfig(require_justification=False)
+        mgr = OverrideManager(config=config, storage_path=tmp_path / "overrides")
+        gate = _make_gate_result()
+        result = mgr.request_override(gate, user="alice", justification="")
+        assert result.approved
+
+
+# --- Rate limiting ---
+
+
+class TestRateLimiting:
+    def test_under_limit(self, tmp_path):
+        config = OverridesConfig(max_overrides_per_user_per_week=3)
+        mgr = OverrideManager(config=config, storage_path=tmp_path / "overrides")
+        gate = _make_gate_result()
+
+        r1 = mgr.request_override(gate, user="alice", justification="reason 1")
+        r2 = mgr.request_override(gate, user="alice", justification="reason 2")
+        assert r1.approved
+        assert r2.approved
+
+    def test_at_limit_denied(self, tmp_path):
+        config = OverridesConfig(max_overrides_per_user_per_week=2)
+        mgr = OverrideManager(config=config, storage_path=tmp_path / "overrides")
+        gate = _make_gate_result()
+
+        mgr.request_override(gate, user="alice", justification="reason 1")
+        mgr.request_override(gate, user="alice", justification="reason 2")
+        r3 = mgr.request_override(gate, user="alice", justification="reason 3")
+        assert not r3.approved
+        assert "limit" in r3.reason.lower()
+
+    def test_different_users_independent(self, tmp_path):
+        config = OverridesConfig(max_overrides_per_user_per_week=1)
+        mgr = OverrideManager(config=config, storage_path=tmp_path / "overrides")
+        gate = _make_gate_result()
+
+        mgr.request_override(gate, user="alice", justification="reason")
+        r_bob = mgr.request_override(gate, user="bob", justification="reason")
+        assert r_bob.approved
+
+    def test_escalations_dont_count_toward_limit(self, tmp_path):
+        config = OverridesConfig(max_overrides_per_user_per_week=1)
+        mgr = OverrideManager(config=config, storage_path=tmp_path / "overrides")
+        gate = _make_gate_result()
+
+        # Escalate (should not count)
+        mgr.request_escalation(gate, user="alice", justification="escalate reason")
+        # Override should still work
+        result = mgr.request_override(gate, user="alice", justification="override reason")
+        assert result.approved
+
+
+# --- Escalation ---
+
+
+class TestEscalation:
+    def test_basic_escalation(self, tmp_path):
+        mgr = OverrideManager(storage_path=tmp_path / "overrides")
+        gate = _make_gate_result()
+        result = mgr.request_escalation(gate, user="alice", justification="Need tech team review.")
+        assert not result.approved  # Escalation is not an approval
+        assert result.record is not None
+        assert result.record.override_type == "escalate"
+        assert result.record.review_outcome == "pending"
+
+    def test_pending_escalations(self, tmp_path):
+        mgr = OverrideManager(storage_path=tmp_path / "overrides")
+        gate = _make_gate_result()
+        mgr.request_escalation(gate, user="alice", justification="reason 1")
+        mgr.request_escalation(gate, user="bob", justification="reason 2")
+
+        pending = mgr.get_pending_escalations()
+        assert len(pending) == 2
+
+    def test_resolve_escalation_approved(self, tmp_path):
+        mgr = OverrideManager(storage_path=tmp_path / "overrides")
+        gate = _make_gate_result()
+        result = mgr.request_escalation(gate, user="alice", justification="need help")
+        override_id = result.record.id
+
+        success = mgr.resolve_escalation(override_id, reviewer="tech_lead", outcome="approved")
+        assert success
+
+        # Verify the record was updated
+        pending = mgr.get_pending_escalations()
+        assert len(pending) == 0
+
+        records = mgr._read_all_records()
+        resolved = [r for r in records if r.id == override_id]
+        assert len(resolved) == 1
+        assert resolved[0].reviewed_by == "tech_lead"
+        assert resolved[0].review_outcome == "approved"
+
+    def test_resolve_escalation_rejected(self, tmp_path):
+        mgr = OverrideManager(storage_path=tmp_path / "overrides")
+        gate = _make_gate_result()
+        result = mgr.request_escalation(gate, user="alice", justification="reason")
+        override_id = result.record.id
+
+        success = mgr.resolve_escalation(override_id, reviewer="tech_lead", outcome="rejected")
+        assert success
+
+        records = mgr._read_all_records()
+        resolved = [r for r in records if r.id == override_id]
+        assert resolved[0].review_outcome == "rejected"
+
+    def test_resolve_invalid_outcome(self, tmp_path):
+        mgr = OverrideManager(storage_path=tmp_path / "overrides")
+        gate = _make_gate_result()
+        result = mgr.request_escalation(gate, user="alice", justification="reason")
+
+        success = mgr.resolve_escalation(result.record.id, reviewer="tech_lead", outcome="maybe")
+        assert not success
+
+    def test_resolve_nonexistent_id(self, tmp_path):
+        mgr = OverrideManager(storage_path=tmp_path / "overrides")
+        success = mgr.resolve_escalation("nonexistent-id", reviewer="tech_lead", outcome="approved")
+        assert not success
+
+
+# --- User queries ---
+
+
+class TestUserQueries:
+    def test_get_user_overrides(self, tmp_path):
+        mgr = OverrideManager(storage_path=tmp_path / "overrides")
+        gate = _make_gate_result()
+        mgr.request_override(gate, user="alice", justification="reason 1")
+        mgr.request_override(gate, user="alice", justification="reason 2")
+        mgr.request_override(gate, user="bob", justification="reason 3")
+
+        alice_records = mgr.get_user_overrides("alice")
+        assert len(alice_records) == 2
+
+        bob_records = mgr.get_user_overrides("bob")
+        assert len(bob_records) == 1
+
+    def test_get_override_stats(self, tmp_path):
+        config = OverridesConfig(max_overrides_per_user_per_week=5)
+        mgr = OverrideManager(config=config, storage_path=tmp_path / "overrides")
+        gate = _make_gate_result()
+        mgr.request_override(gate, user="alice", justification="reason 1")
+        mgr.request_override(gate, user="alice", justification="reason 2")
+        mgr.request_escalation(gate, user="alice", justification="escalate")
+
+        stats = mgr.get_override_stats("alice")
+        assert stats["total_overrides"] == 3
+        assert stats["weekly_overrides"] == 2  # Only "proceed" type
+        assert stats["weekly_limit"] == 5
+        assert stats["remaining_this_week"] == 3
+        assert stats["pending_escalations"] == 1
+
+
+# --- Persistence ---
+
+
+class TestPersistence:
+    def test_records_persist(self, tmp_path):
+        storage = tmp_path / "overrides"
+        gate = _make_gate_result()
+
+        # Create and write
+        mgr1 = OverrideManager(storage_path=storage)
+        mgr1.request_override(gate, user="alice", justification="reason")
+
+        # New manager reads from same path
+        mgr2 = OverrideManager(storage_path=storage)
+        records = mgr2._read_all_records()
+        assert len(records) == 1
+        assert records[0].user == "alice"
+
+    def test_empty_storage(self, tmp_path):
+        mgr = OverrideManager(storage_path=tmp_path / "overrides")
+        records = mgr._read_all_records()
+        assert records == []
+        pending = mgr.get_pending_escalations()
+        assert pending == []


### PR DESCRIPTION
## Summary
- Implements issue #15: Override Workflow with Audit Logging
- `OverrideManager` handles override requests, escalations, and resolutions
- Rate limiting: configurable max overrides per user per week (default: 3)
- Escalation workflow: pending → approved/rejected by tech team
- JSONL audit trail with `OverrideRecord` model (new in shared/models.py)
- Query methods: `get_pending_escalations()`, `get_user_overrides()`, `get_override_stats()`
- 20 tests covering overrides, justification, rate limits, escalation, persistence

## Test plan
- [x] All 20 override tests pass
- [x] Full suite: 525 tests pass
- [x] Lint clean (ruff check + format)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)