### PR TITLE
feat(p2): anti-gaming measures for rubric score integrity

### DIFF
--- a/gate/patterns/anti_gaming.py
+++ b/gate/patterns/anti_gaming.py
@@ -1,0 +1,353 @@
+"""Anti-gaming measures for rubric scores.
+
+Detects patterns where AI or users optimize for passing the rubric
+without actually improving code quality. Each checker produces findings
+with score adjustments applied before tier evaluation.
+
+Gaming patterns detected:
+1. Comment stuffing — meaningless or tautological comments
+2. Try/catch wrapping — bare except with pass
+3. Trivial file splitting — (checked at aggregate level, not here)
+4. Test stub padding — test functions with no assertions
+5. Length inflation — verbose code relative to purpose
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass
+
+from shared.models import Dimension, ScoreResult
+
+
+@dataclass
+class GamingFinding:
+    """A detected score gaming pattern."""
+
+    pattern: str
+    description: str
+    score_adjustment: float  # Negative value to subtract
+    dimension_affected: str  # Dimension to adjust
+    line_number: int = 0
+
+
+class AntiGamingChecker:
+    """Detects potential score gaming and returns adjustment findings."""
+
+    def check(
+        self,
+        code: str,
+        score_result: ScoreResult | None = None,
+        test_code: str = "",
+    ) -> list[GamingFinding]:
+        """Detect potential score gaming.
+
+        Args:
+            code: The source code to analyze.
+            score_result: The scoring result (for context).
+            test_code: Associated test code (for test stub detection).
+
+        Returns:
+            List of gaming findings with score adjustments.
+        """
+        findings: list[GamingFinding] = []
+
+        findings.extend(self._check_comment_stuffing(code))
+        findings.extend(self._check_try_catch_wrapping(code))
+        findings.extend(self._check_test_stub_padding(test_code))
+        findings.extend(self._check_length_inflation(code))
+
+        return findings
+
+    def apply_adjustments(
+        self,
+        score_result: ScoreResult,
+        findings: list[GamingFinding],
+    ) -> ScoreResult:
+        """Apply gaming adjustments to a score result.
+
+        Returns a new ScoreResult with adjusted dimension scores.
+        Does not modify the original.
+        """
+        if not findings:
+            return score_result
+
+        # Build adjustment map: dimension -> total adjustment
+        adjustments: dict[str, float] = {}
+        for finding in findings:
+            dim = finding.dimension_affected
+            adjustments[dim] = adjustments.get(dim, 0.0) + finding.score_adjustment
+
+        # Apply adjustments to dimension scores
+        new_dims = []
+        for ds in score_result.dimension_scores:
+            adj = adjustments.get(ds.dimension.value, 0.0)
+            new_score = max(0.0, min(1.0, ds.score + adj))
+            new_ds = ds.model_copy(update={"score": new_score})
+            new_dims.append(new_ds)
+
+        # Recalculate composite (simple average for now)
+        if new_dims:
+            new_composite = sum(d.score for d in new_dims) / len(new_dims)
+        else:
+            new_composite = score_result.composite_score
+
+        new_composite = max(0.0, min(1.0, new_composite))
+
+        return score_result.model_copy(
+            update={
+                "dimension_scores": new_dims,
+                "composite_score": new_composite,
+            }
+        )
+
+    # --- Comment Stuffing ---
+
+    def _check_comment_stuffing(self, code: str) -> list[GamingFinding]:
+        """Detect meaningless or tautological comments."""
+        findings: list[GamingFinding] = []
+        lines = code.splitlines()
+        tautological_count = 0
+        total_comments = 0
+
+        for line_num, line in enumerate(lines, 1):
+            stripped = line.strip()
+
+            # Skip docstrings and non-comment lines
+            if not stripped.startswith("#"):
+                continue
+
+            comment_text = stripped.lstrip("#").strip().lower()
+            if not comment_text:
+                continue
+
+            total_comments += 1
+
+            # Check for tautological comments (comment just describes the code)
+            if self._is_tautological(comment_text, lines, line_num):
+                tautological_count += 1
+
+            # Check for generic filler comments
+            if self._is_filler(comment_text):
+                tautological_count += 1
+
+        # Only flag if a significant portion of comments are stuffed
+        if total_comments >= 3 and tautological_count / total_comments > 0.5:
+            findings.append(
+                GamingFinding(
+                    pattern="comment_stuffing",
+                    description=(
+                        f"{tautological_count}/{total_comments} comments appear "
+                        "tautological or generic. Comments should add context "
+                        "beyond what the code already says."
+                    ),
+                    score_adjustment=-0.15,
+                    dimension_affected=Dimension.DOCUMENTATION.value,
+                )
+            )
+
+        return findings
+
+    @staticmethod
+    def _is_tautological(comment: str, lines: list[str], line_num: int) -> bool:
+        """Check if a comment is a tautological restatement of adjacent code."""
+        # Look at the next non-empty line
+        for i in range(line_num, min(line_num + 2, len(lines))):
+            next_line = lines[i].strip().lower()
+            if not next_line or next_line.startswith("#"):
+                continue
+
+            # Extract identifiers from the code line
+            code_tokens = set(re.findall(r"[a-z_][a-z0-9_]*", next_line))
+            comment_tokens = set(re.findall(r"[a-z_][a-z0-9_]*", comment))
+
+            # If the comment is just the code tokens restated
+            if code_tokens and comment_tokens:
+                overlap = code_tokens & comment_tokens
+                if len(overlap) >= len(comment_tokens) * 0.7 and len(comment_tokens) >= 2:
+                    return True
+
+            break
+
+        return False
+
+    @staticmethod
+    def _is_filler(comment: str) -> bool:
+        """Check if a comment is generic filler."""
+        filler_patterns = [
+            r"^do the thing$",
+            r"^process data$",
+            r"^handle (?:the )?(?:data|input|output|result)$",
+            r"^set \w+ to \w+$",
+            r"^initialize \w+$",
+            r"^create \w+$",
+            r"^get \w+$",
+            r"^return \w+$",
+            r"^call \w+$",
+            r"^update \w+$",
+            r"^define \w+$",
+            r"^assign \w+$",
+            r"^import \w+$",
+        ]
+        for pattern in filler_patterns:
+            if re.match(pattern, comment):
+                return True
+        return False
+
+    # --- Try/Catch Wrapping ---
+
+    def _check_try_catch_wrapping(self, code: str) -> list[GamingFinding]:
+        """Detect bare except clauses with pass (exception swallowing)."""
+        findings: list[GamingFinding] = []
+
+        try:
+            tree = ast.parse(code)
+        except SyntaxError:
+            return findings
+
+        swallowed = 0
+        total_handlers = 0
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ExceptHandler):
+                total_handlers += 1
+                if self._is_swallowed(node):
+                    swallowed += 1
+
+        if swallowed >= 2:
+            findings.append(
+                GamingFinding(
+                    pattern="try_catch_wrapping",
+                    description=(
+                        f"{swallowed} exception handlers just use 'pass' or do nothing. "
+                        "Exceptions should be logged, re-raised, or handled specifically."
+                    ),
+                    score_adjustment=-0.1,
+                    dimension_affected=Dimension.CORRECTNESS.value,
+                )
+            )
+
+        return findings
+
+    @staticmethod
+    def _is_swallowed(handler: ast.ExceptHandler) -> bool:
+        """Check if an exception handler swallows the exception."""
+        body = handler.body
+        if len(body) == 1:
+            stmt = body[0]
+            # `except: pass`
+            if isinstance(stmt, ast.Pass):
+                return True
+            # `except: ...` (Ellipsis)
+            if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant):
+                if stmt.value.value is ...:
+                    return True
+        return False
+
+    # --- Test Stub Padding ---
+
+    def _check_test_stub_padding(self, test_code: str) -> list[GamingFinding]:
+        """Detect test functions with no meaningful assertions."""
+        if not test_code.strip():
+            return []
+
+        findings: list[GamingFinding] = []
+
+        try:
+            tree = ast.parse(test_code)
+        except SyntaxError:
+            return findings
+
+        total_tests = 0
+        empty_tests = 0
+
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name.startswith("test_"):
+                    total_tests += 1
+                    if not self._has_assertion(node):
+                        empty_tests += 1
+
+        if total_tests >= 2 and empty_tests / total_tests > 0.5:
+            findings.append(
+                GamingFinding(
+                    pattern="test_stub_padding",
+                    description=(
+                        f"{empty_tests}/{total_tests} test functions lack assertions. "
+                        "Tests should verify behavior with assert statements."
+                    ),
+                    score_adjustment=-0.15,
+                    dimension_affected=Dimension.TESTABILITY.value,
+                )
+            )
+
+        return findings
+
+    @staticmethod
+    def _has_assertion(func_node: ast.FunctionDef) -> bool:
+        """Check if a function contains any assertion."""
+        for node in ast.walk(func_node):
+            # assert statements
+            if isinstance(node, ast.Assert):
+                return True
+            # pytest-style: self.assert*, self.assertEqual, etc.
+            if isinstance(node, ast.Call):
+                func = node.func
+                if isinstance(func, ast.Attribute):
+                    if func.attr.startswith("assert"):
+                        return True
+                # pytest.raises context manager
+                if isinstance(func, ast.Attribute) and func.attr == "raises":
+                    return True
+        return False
+
+    # --- Length Inflation ---
+
+    def _check_length_inflation(self, code: str) -> list[GamingFinding]:
+        """Detect verbose code that could be significantly shorter."""
+        findings: list[GamingFinding] = []
+
+        try:
+            tree = ast.parse(code)
+        except SyntaxError:
+            return findings
+
+        lines = code.splitlines()
+        total_lines = len(lines)
+        if total_lines < 50:
+            return findings
+
+        # Count functional elements vs boilerplate
+        functions = []
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                functions.append(node)
+
+        if not functions:
+            return findings
+
+        # Check for excessively verbose functions (lots of lines, few statements)
+        verbose_functions = 0
+        for func in functions:
+            func_lines = (func.end_lineno or func.lineno) - func.lineno + 1
+            stmt_count = sum(1 for _ in ast.walk(func) if isinstance(_, ast.stmt))
+            if func_lines > 20 and stmt_count > 0:
+                ratio = func_lines / stmt_count
+                if ratio > 5:  # More than 5 lines per statement = very verbose
+                    verbose_functions += 1
+
+        if verbose_functions >= 2:
+            findings.append(
+                GamingFinding(
+                    pattern="length_inflation",
+                    description=(
+                        f"{verbose_functions} functions appear excessively verbose "
+                        "(high line-to-statement ratio). Consider more concise code."
+                    ),
+                    score_adjustment=-0.1,
+                    dimension_affected=Dimension.MAINTAINABILITY.value,
+                )
+            )
+
+        return findings

--- a/tests/gate/test_anti_gaming.py
+++ b/tests/gate/test_anti_gaming.py
@@ -1,0 +1,343 @@
+"""Tests for anti-gaming measures."""
+
+from shared.models import Dimension, DimensionScore, ScoreResult, ScoringMethod
+
+from gate.patterns.anti_gaming import AntiGamingChecker, GamingFinding
+
+
+def _make_score(
+    composite: float = 0.8,
+    dims: list[tuple[Dimension, float]] | None = None,
+) -> ScoreResult:
+    dim_scores = []
+    if dims:
+        for dim, val in dims:
+            dim_scores.append(
+                DimensionScore(dimension=dim, score=val, method=ScoringMethod.RULE_BASED)
+            )
+    return ScoreResult(user="test", composite_score=composite, dimension_scores=dim_scores)
+
+
+# --- Comment Stuffing ---
+
+
+class TestCommentStuffing:
+    def setup_method(self):
+        self.checker = AntiGamingChecker()
+
+    def test_tautological_comments_detected(self):
+        code = (
+            "# set x to 5\n"
+            "x = 5\n"
+            "# set y to 10\n"
+            "y = 10\n"
+            "# return result\n"
+            "return result\n"
+            "# update count\n"
+            "count += 1\n"
+        )
+        findings = self.checker.check(code)
+        assert any(f.pattern == "comment_stuffing" for f in findings)
+
+    def test_meaningful_comments_ok(self):
+        code = (
+            "# Calculate the weighted average using exponential decay\n"
+            "avg = sum(w * v for w, v in zip(weights, values))\n"
+            "# Clamp to valid range to prevent overflow in downstream calcs\n"
+            "result = max(0.0, min(1.0, avg))\n"
+            "# Edge case: empty input returns sentinel value per API contract\n"
+            "if not values:\n"
+            "    return -1.0\n"
+        )
+        findings = self.checker.check(code)
+        assert not any(f.pattern == "comment_stuffing" for f in findings)
+
+    def test_filler_comments_detected(self):
+        code = (
+            "# process data\n"
+            "data = load()\n"
+            "# handle the input\n"
+            "result = process(data)\n"
+            "# do the thing\n"
+            "execute(result)\n"
+        )
+        findings = self.checker.check(code)
+        assert any(f.pattern == "comment_stuffing" for f in findings)
+
+    def test_few_comments_not_flagged(self):
+        # Less than 3 comments shouldn't trigger
+        code = "# set x to 5\nx = 5\ny = 10\n"
+        findings = self.checker.check(code)
+        assert not any(f.pattern == "comment_stuffing" for f in findings)
+
+    def test_adjustment_targets_documentation(self):
+        code = "# set x to 5\nx = 5\n# set y to 10\ny = 10\n# return result\nreturn result\n"
+        findings = self.checker.check(code)
+        stuffing = [f for f in findings if f.pattern == "comment_stuffing"]
+        if stuffing:
+            assert stuffing[0].dimension_affected == Dimension.DOCUMENTATION.value
+            assert stuffing[0].score_adjustment < 0
+
+
+# --- Try/Catch Wrapping ---
+
+
+class TestTryCatchWrapping:
+    def setup_method(self):
+        self.checker = AntiGamingChecker()
+
+    def test_swallowed_exceptions_detected(self):
+        code = (
+            "try:\n"
+            "    do_something()\n"
+            "except Exception:\n"
+            "    pass\n"
+            "try:\n"
+            "    do_another()\n"
+            "except:\n"
+            "    pass\n"
+        )
+        findings = self.checker.check(code)
+        assert any(f.pattern == "try_catch_wrapping" for f in findings)
+
+    def test_handled_exceptions_ok(self):
+        code = (
+            "try:\n"
+            "    result = risky_operation()\n"
+            "except ValueError as e:\n"
+            "    logger.error(f'Failed: {e}')\n"
+            "    raise\n"
+            "try:\n"
+            "    data = load_file(path)\n"
+            "except FileNotFoundError:\n"
+            "    data = default_data()\n"
+        )
+        findings = self.checker.check(code)
+        assert not any(f.pattern == "try_catch_wrapping" for f in findings)
+
+    def test_single_swallow_not_flagged(self):
+        # One swallowed exception is tolerable
+        code = "try:\n    optional_cleanup()\nexcept Exception:\n    pass\n"
+        findings = self.checker.check(code)
+        assert not any(f.pattern == "try_catch_wrapping" for f in findings)
+
+    def test_ellipsis_handler_detected(self):
+        code = "try:\n    a()\nexcept:\n    ...\ntry:\n    b()\nexcept:\n    ...\n"
+        findings = self.checker.check(code)
+        assert any(f.pattern == "try_catch_wrapping" for f in findings)
+
+    def test_adjustment_targets_correctness(self):
+        code = "try:\n    a()\nexcept:\n    pass\ntry:\n    b()\nexcept:\n    pass\n"
+        findings = self.checker.check(code)
+        wrapping = [f for f in findings if f.pattern == "try_catch_wrapping"]
+        assert wrapping[0].dimension_affected == Dimension.CORRECTNESS.value
+        assert wrapping[0].score_adjustment < 0
+
+
+# --- Test Stub Padding ---
+
+
+class TestTestStubPadding:
+    def setup_method(self):
+        self.checker = AntiGamingChecker()
+
+    def test_empty_tests_detected(self):
+        test_code = (
+            "def test_one():\n    pass\ndef test_two():\n    pass\ndef test_three():\n    pass\n"
+        )
+        findings = self.checker.check("", test_code=test_code)
+        assert any(f.pattern == "test_stub_padding" for f in findings)
+
+    def test_tests_with_assertions_ok(self):
+        test_code = (
+            "def test_add():\n"
+            "    assert add(1, 2) == 3\n"
+            "def test_subtract():\n"
+            "    assert subtract(5, 3) == 2\n"
+        )
+        findings = self.checker.check("", test_code=test_code)
+        assert not any(f.pattern == "test_stub_padding" for f in findings)
+
+    def test_no_test_functions_ok(self):
+        test_code = "def helper():\n    return 42\n"
+        findings = self.checker.check("", test_code=test_code)
+        assert not any(f.pattern == "test_stub_padding" for f in findings)
+
+    def test_mixed_tests_threshold(self):
+        # 1 empty out of 3 = 33%, below 50% threshold
+        test_code = (
+            "def test_a():\n"
+            "    assert True\n"
+            "def test_b():\n"
+            "    assert 1 == 1\n"
+            "def test_c():\n"
+            "    pass\n"
+        )
+        findings = self.checker.check("", test_code=test_code)
+        assert not any(f.pattern == "test_stub_padding" for f in findings)
+
+    def test_call_without_assert_detected(self):
+        test_code = (
+            "def test_one():\n"
+            "    result = do_something()\n"
+            "def test_two():\n"
+            "    process()\n"
+            "def test_three():\n"
+            "    run()\n"
+        )
+        findings = self.checker.check("", test_code=test_code)
+        assert any(f.pattern == "test_stub_padding" for f in findings)
+
+    def test_adjustment_targets_testability(self):
+        test_code = "def test_a():\n    pass\ndef test_b():\n    pass\n"
+        findings = self.checker.check("", test_code=test_code)
+        padding = [f for f in findings if f.pattern == "test_stub_padding"]
+        assert padding[0].dimension_affected == Dimension.TESTABILITY.value
+        assert padding[0].score_adjustment < 0
+
+    def test_empty_test_code_ok(self):
+        findings = self.checker.check("x = 1", test_code="")
+        assert not any(f.pattern == "test_stub_padding" for f in findings)
+
+
+# --- Length Inflation ---
+
+
+class TestLengthInflation:
+    def setup_method(self):
+        self.checker = AntiGamingChecker()
+
+    def test_short_code_not_flagged(self):
+        code = "x = 1\ny = 2\n"
+        findings = self.checker.check(code)
+        assert not any(f.pattern == "length_inflation" for f in findings)
+
+    def test_concise_code_ok(self):
+        # Normal density code
+        lines = []
+        for i in range(10):
+            lines.append(f"def func_{i}(x):")
+            lines.append(f"    return x + {i}")
+            lines.append("")
+        code = "\n".join(lines)
+        findings = self.checker.check(code)
+        assert not any(f.pattern == "length_inflation" for f in findings)
+
+    def test_clean_code_no_findings(self):
+        code = "def add(a, b):\n    return a + b\n"
+        findings = self.checker.check(code)
+        assert len(findings) == 0
+
+
+# --- Score Adjustment ---
+
+
+class TestScoreAdjustment:
+    def setup_method(self):
+        self.checker = AntiGamingChecker()
+
+    def test_apply_no_findings(self):
+        score = _make_score(
+            composite=0.8,
+            dims=[(Dimension.DOCUMENTATION, 0.8)],
+        )
+        result = self.checker.apply_adjustments(score, [])
+        assert result.composite_score == 0.8
+
+    def test_apply_single_adjustment(self):
+        score = _make_score(
+            composite=0.8,
+            dims=[(Dimension.DOCUMENTATION, 0.8)],
+        )
+        finding = GamingFinding(
+            pattern="comment_stuffing",
+            description="test",
+            score_adjustment=-0.15,
+            dimension_affected=Dimension.DOCUMENTATION.value,
+        )
+        result = self.checker.apply_adjustments(score, [finding])
+        doc_score = next(
+            d.score for d in result.dimension_scores if d.dimension == Dimension.DOCUMENTATION
+        )
+        assert abs(doc_score - 0.65) < 0.01
+
+    def test_adjustment_floors_at_zero(self):
+        score = _make_score(
+            composite=0.1,
+            dims=[(Dimension.CORRECTNESS, 0.05)],
+        )
+        finding = GamingFinding(
+            pattern="try_catch_wrapping",
+            description="test",
+            score_adjustment=-0.2,
+            dimension_affected=Dimension.CORRECTNESS.value,
+        )
+        result = self.checker.apply_adjustments(score, [finding])
+        corr_score = next(
+            d.score for d in result.dimension_scores if d.dimension == Dimension.CORRECTNESS
+        )
+        assert corr_score == 0.0
+
+    def test_multiple_adjustments(self):
+        score = _make_score(
+            composite=0.8,
+            dims=[
+                (Dimension.DOCUMENTATION, 0.8),
+                (Dimension.CORRECTNESS, 0.7),
+            ],
+        )
+        findings = [
+            GamingFinding(
+                pattern="comment_stuffing",
+                description="test",
+                score_adjustment=-0.15,
+                dimension_affected=Dimension.DOCUMENTATION.value,
+            ),
+            GamingFinding(
+                pattern="try_catch_wrapping",
+                description="test",
+                score_adjustment=-0.1,
+                dimension_affected=Dimension.CORRECTNESS.value,
+            ),
+        ]
+        result = self.checker.apply_adjustments(score, findings)
+        assert result.composite_score < 0.8
+
+    def test_original_not_modified(self):
+        score = _make_score(
+            composite=0.8,
+            dims=[(Dimension.DOCUMENTATION, 0.8)],
+        )
+        finding = GamingFinding(
+            pattern="comment_stuffing",
+            description="test",
+            score_adjustment=-0.15,
+            dimension_affected=Dimension.DOCUMENTATION.value,
+        )
+        self.checker.apply_adjustments(score, [finding])
+        # Original should be unchanged
+        assert score.composite_score == 0.8
+        assert score.dimension_scores[0].score == 0.8
+
+
+# --- Integration ---
+
+
+class TestIntegration:
+    def test_check_and_apply(self):
+        checker = AntiGamingChecker()
+        code = "# set x to 5\nx = 5\n# set y to 10\ny = 10\n# return result\nreturn result\n"
+        score = _make_score(
+            composite=0.8,
+            dims=[(Dimension.DOCUMENTATION, 0.9)],
+        )
+        findings = checker.check(code)
+        if findings:
+            adjusted = checker.apply_adjustments(score, findings)
+            assert adjusted.composite_score <= score.composite_score
+
+    def test_clean_code_no_adjustment(self):
+        checker = AntiGamingChecker()
+        code = "def add(a, b):\n    return a + b\n"
+        findings = checker.check(code)
+        assert len(findings) == 0


### PR DESCRIPTION
## Summary
- Implements issue #16: Anti-Gaming Measures
- `AntiGamingChecker` detects 4 score gaming patterns:
  - **Comment stuffing**: tautological/filler comments inflating documentation score
  - **Try/catch wrapping**: bare `except: pass` handlers swallowing exceptions
  - **Test stub padding**: test functions without assertions
  - **Length inflation**: excessively verbose functions (high line-to-statement ratio)
- `apply_adjustments()` applies negative score adjustments immutably
- Thresholds prevent false positives (e.g., single swallowed exception tolerated)
- 27 tests covering detection, false positive avoidance, adjustment math, and integration

## Test plan
- [x] All 27 anti-gaming tests pass
- [x] Full suite: 552 tests pass
- [x] Lint clean (ruff check + format)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)