### PR TITLE
feat: graduation tier model and rubrics (T0-T3)

### DIFF
--- a/registry/graduation/rubrics.py
+++ b/registry/graduation/rubrics.py
@@ -1,0 +1,414 @@
+"""Graduation rubrics for tier transitions.
+
+Evaluates whether a tool is ready to graduate from one tier to the next.
+Rubric criteria are data-driven: loaded from config dicts that can be
+provided via YAML configuration.
+
+Each transition (T0→T1, T1→T2, T2→T3) has a rubric defining required
+and advisory checklist items. Items are evaluated against the tool's
+registry entry and scorecard summary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from shared.models import ToolRegistryEntry, ToolTier
+
+from registry.graduation.tiers import is_valid_transition
+
+
+# --- Data Models ---
+
+
+@dataclass
+class ChecklistItem:
+    """A single graduation checklist item."""
+
+    requirement: str
+    met: bool = False
+    details: str = ""
+    blocking: bool = True  # If True, must be met to graduate
+
+
+@dataclass
+class GraduationResult:
+    """Result of evaluating a tool against graduation criteria."""
+
+    ready: bool
+    from_tier: ToolTier
+    to_tier: ToolTier
+    checklist: list[ChecklistItem] = field(default_factory=list)
+    blocking_items: list[ChecklistItem] = field(default_factory=list)
+    advisory_items: list[ChecklistItem] = field(default_factory=list)
+    overall_readiness: float = 0.0  # 0.0-1.0
+
+
+# --- Default Rubric Configs ---
+
+# These can be overridden via YAML config. Each criterion has:
+#   requirement: human-readable description
+#   check: name of the check function to run
+#   blocking: whether it blocks graduation
+#   params: optional parameters for the check
+
+DEFAULT_T0_TO_T1: list[dict[str, Any]] = [
+    {
+        "requirement": "Tool has a description (README or header comment)",
+        "check": "has_description",
+        "blocking": True,
+    },
+    {
+        "requirement": "No unresolved red-tier security issues",
+        "check": "no_red_flags",
+        "blocking": True,
+    },
+    {
+        "requirement": "At least 2 users registered",
+        "check": "min_users",
+        "blocking": True,
+        "params": {"min": 2},
+    },
+    {
+        "requirement": "Source path is set",
+        "check": "has_source_path",
+        "blocking": False,
+    },
+]
+
+DEFAULT_T1_TO_T2: list[dict[str, Any]] = [
+    {
+        "requirement": "Composite quality score >= 0.7",
+        "check": "min_composite_score",
+        "blocking": True,
+        "params": {"min": 0.7},
+    },
+    {
+        "requirement": "Zero unresolved red-tier issues",
+        "check": "no_red_flags",
+        "blocking": True,
+    },
+    {
+        "requirement": "Basic test coverage exists",
+        "check": "has_test_coverage",
+        "blocking": True,
+    },
+    {
+        "requirement": "Tech owner assigned",
+        "check": "has_tech_owner",
+        "blocking": True,
+    },
+    {
+        "requirement": "Dependencies vetted and pinned",
+        "check": "dependencies_pinned",
+        "blocking": True,
+    },
+    {
+        "requirement": "Code review completed by tech team member",
+        "check": "has_code_review",
+        "blocking": False,
+    },
+]
+
+DEFAULT_T2_TO_T3: list[dict[str, Any]] = [
+    {
+        "requirement": "Full test coverage (unit + integration)",
+        "check": "full_test_coverage",
+        "blocking": True,
+    },
+    {
+        "requirement": "Security review completed",
+        "check": "security_review_done",
+        "blocking": True,
+    },
+    {
+        "requirement": "Error handling and logging implemented",
+        "check": "has_error_handling",
+        "blocking": True,
+    },
+    {
+        "requirement": "Rollback plan documented",
+        "check": "has_rollback_plan",
+        "blocking": True,
+    },
+    {
+        "requirement": "Monitoring and alerting configured",
+        "check": "has_monitoring",
+        "blocking": True,
+    },
+    {
+        "requirement": "Knowledge transfer completed",
+        "check": "knowledge_transfer_done",
+        "blocking": True,
+    },
+    {
+        "requirement": "Composite quality score >= 0.8",
+        "check": "min_composite_score",
+        "blocking": True,
+        "params": {"min": 0.8},
+    },
+    {
+        "requirement": "At least 3 users",
+        "check": "min_users",
+        "blocking": False,
+        "params": {"min": 3},
+    },
+]
+
+# Map transitions to their default configs
+_DEFAULT_RUBRICS: dict[tuple[ToolTier, ToolTier], list[dict[str, Any]]] = {
+    (ToolTier.T0, ToolTier.T1): DEFAULT_T0_TO_T1,
+    (ToolTier.T1, ToolTier.T2): DEFAULT_T1_TO_T2,
+    (ToolTier.T2, ToolTier.T3): DEFAULT_T2_TO_T3,
+}
+
+
+# --- Check Functions ---
+
+
+def _check_has_description(tool: ToolRegistryEntry, **_: Any) -> tuple[bool, str]:
+    """Check if the tool has a description."""
+    if tool.description.strip():
+        return True, f"Description: {tool.description[:60]}"
+    return False, "No description set. Add a README or description."
+
+
+def _check_no_red_flags(tool: ToolRegistryEntry, **_: Any) -> tuple[bool, str]:
+    """Check if the tool has no red flags."""
+    if tool.scorecard.red_flags == 0:
+        return True, "No red-tier issues found."
+    return False, f"{tool.scorecard.red_flags} red-tier issue(s) unresolved."
+
+
+def _check_min_users(tool: ToolRegistryEntry, *, min: int = 2, **_: Any) -> tuple[bool, str]:
+    """Check if the tool has enough users."""
+    count = len(tool.users)
+    if count >= min:
+        return True, f"{count} user(s) registered (minimum: {min})."
+    return False, f"Only {count} user(s) registered (minimum: {min})."
+
+
+def _check_has_source_path(tool: ToolRegistryEntry, **_: Any) -> tuple[bool, str]:
+    """Check if source path is set."""
+    if tool.source_path:
+        return True, f"Source: {tool.source_path}"
+    return False, "No source path configured."
+
+
+def _check_min_composite_score(
+    tool: ToolRegistryEntry, *, min: float = 0.7, **_: Any
+) -> tuple[bool, str]:
+    """Check if composite score meets minimum."""
+    score = tool.scorecard.latest_composite
+    if score >= min:
+        return True, f"Composite score: {score:.2f} (minimum: {min:.2f})."
+    return False, f"Composite score: {score:.2f} (minimum: {min:.2f})."
+
+
+def _check_has_tech_owner(tool: ToolRegistryEntry, **_: Any) -> tuple[bool, str]:
+    """Check if a tech owner is assigned."""
+    if tool.tech_owner:
+        return True, f"Tech owner: {tool.tech_owner}"
+    return False, "No tech owner assigned."
+
+
+def _check_has_test_coverage(tool: ToolRegistryEntry, **_: Any) -> tuple[bool, str]:
+    """Check if basic test coverage exists."""
+    test_score = tool.scorecard.latest_scores.get("testability", 0.0)
+    if test_score >= 0.5:
+        return True, f"Testability score: {test_score:.2f}."
+    return False, f"Testability score: {test_score:.2f} (minimum: 0.50)."
+
+
+def _check_dependencies_pinned(tool: ToolRegistryEntry, **_: Any) -> tuple[bool, str]:
+    """Check if dependencies are pinned (via metadata flag)."""
+    if tool.metadata.get("dependencies_pinned", False):
+        return True, "Dependencies are pinned."
+    return False, "Dependencies not confirmed as pinned."
+
+
+def _check_has_code_review(tool: ToolRegistryEntry, **_: Any) -> tuple[bool, str]:
+    """Check if code review has been completed (via metadata flag)."""
+    if tool.metadata.get("code_reviewed", False):
+        return True, "Code review completed."
+    return False, "Code review not completed."
+
+
+def _check_full_test_coverage(tool: ToolRegistryEntry, **_: Any) -> tuple[bool, str]:
+    """Check if full test coverage exists."""
+    test_score = tool.scorecard.latest_scores.get("testability", 0.0)
+    if test_score >= 0.8:
+        return True, f"Testability score: {test_score:.2f} (full coverage)."
+    return False, f"Testability score: {test_score:.2f} (minimum: 0.80 for full coverage)."
+
+
+def _check_security_review_done(tool: ToolRegistryEntry, **_: Any) -> tuple[bool, str]:
+    """Check if security review has been completed."""
+    if tool.metadata.get("security_reviewed", False):
+        return True, "Security review completed."
+    return False, "Security review not completed."
+
+
+def _check_has_error_handling(tool: ToolRegistryEntry, **_: Any) -> tuple[bool, str]:
+    """Check if error handling and logging is implemented."""
+    if tool.metadata.get("error_handling", False):
+        return True, "Error handling and logging confirmed."
+    return False, "Error handling and logging not confirmed."
+
+
+def _check_has_rollback_plan(tool: ToolRegistryEntry, **_: Any) -> tuple[bool, str]:
+    """Check if a rollback plan is documented."""
+    if tool.metadata.get("rollback_plan", False):
+        return True, "Rollback plan documented."
+    return False, "No rollback plan documented."
+
+
+def _check_has_monitoring(tool: ToolRegistryEntry, **_: Any) -> tuple[bool, str]:
+    """Check if monitoring and alerting is configured."""
+    if tool.metadata.get("monitoring_configured", False):
+        return True, "Monitoring and alerting configured."
+    return False, "Monitoring and alerting not configured."
+
+
+def _check_knowledge_transfer_done(tool: ToolRegistryEntry, **_: Any) -> tuple[bool, str]:
+    """Check if knowledge transfer has been completed."""
+    if tool.metadata.get("knowledge_transfer", False):
+        return True, "Knowledge transfer completed."
+    return False, "Knowledge transfer not completed."
+
+
+# Check function registry
+_CHECK_FUNCTIONS: dict[str, Any] = {
+    "has_description": _check_has_description,
+    "no_red_flags": _check_no_red_flags,
+    "min_users": _check_min_users,
+    "has_source_path": _check_has_source_path,
+    "min_composite_score": _check_min_composite_score,
+    "has_tech_owner": _check_has_tech_owner,
+    "has_test_coverage": _check_has_test_coverage,
+    "dependencies_pinned": _check_dependencies_pinned,
+    "has_code_review": _check_has_code_review,
+    "full_test_coverage": _check_full_test_coverage,
+    "security_review_done": _check_security_review_done,
+    "has_error_handling": _check_has_error_handling,
+    "has_rollback_plan": _check_has_rollback_plan,
+    "has_monitoring": _check_has_monitoring,
+    "knowledge_transfer_done": _check_knowledge_transfer_done,
+}
+
+
+# --- Graduation Rubric ---
+
+
+class GraduationRubric:
+    """Evaluates tool readiness for tier graduation.
+
+    Rubric criteria can be customized via config_overrides, which maps
+    transition tuples to lists of criterion dicts matching the default format.
+    """
+
+    def __init__(
+        self,
+        config_overrides: dict[tuple[ToolTier, ToolTier], list[dict[str, Any]]] | None = None,
+    ) -> None:
+        self._rubrics = dict(_DEFAULT_RUBRICS)
+        if config_overrides:
+            self._rubrics.update(config_overrides)
+
+    def evaluate(
+        self,
+        tool: ToolRegistryEntry,
+        target_tier: ToolTier,
+    ) -> GraduationResult:
+        """Evaluate whether a tool is ready to graduate to target tier.
+
+        Args:
+            tool: The tool registry entry to evaluate.
+            target_tier: The tier to graduate to.
+
+        Returns:
+            GraduationResult with checklist and readiness assessment.
+        """
+        from_tier = tool.tier
+        transition = (from_tier, target_tier)
+
+        if not is_valid_transition(from_tier, target_tier):
+            return GraduationResult(
+                ready=False,
+                from_tier=from_tier,
+                to_tier=target_tier,
+                checklist=[
+                    ChecklistItem(
+                        requirement="Valid tier transition",
+                        met=False,
+                        details=(
+                            f"Cannot transition from {from_tier.value} to "
+                            f"{target_tier.value}. Must be one step up."
+                        ),
+                        blocking=True,
+                    )
+                ],
+                blocking_items=[
+                    ChecklistItem(
+                        requirement="Valid tier transition",
+                        met=False,
+                        details="Invalid transition.",
+                        blocking=True,
+                    )
+                ],
+                overall_readiness=0.0,
+            )
+
+        criteria = self._rubrics.get(transition, [])
+        checklist: list[ChecklistItem] = []
+        blocking: list[ChecklistItem] = []
+        advisory: list[ChecklistItem] = []
+
+        for criterion in criteria:
+            check_name = criterion["check"]
+            params = criterion.get("params", {})
+            is_blocking = criterion.get("blocking", True)
+
+            check_fn = _CHECK_FUNCTIONS.get(check_name)
+            if check_fn is None:
+                item = ChecklistItem(
+                    requirement=criterion["requirement"],
+                    met=False,
+                    details=f"Unknown check: {check_name}",
+                    blocking=is_blocking,
+                )
+            else:
+                met, details = check_fn(tool, **params)
+                item = ChecklistItem(
+                    requirement=criterion["requirement"],
+                    met=met,
+                    details=details,
+                    blocking=is_blocking,
+                )
+
+            checklist.append(item)
+
+            if not item.met and item.blocking:
+                blocking.append(item)
+            elif not item.met and not item.blocking:
+                advisory.append(item)
+
+        # Calculate readiness
+        total = len(checklist)
+        met_count = sum(1 for c in checklist if c.met)
+        readiness = met_count / total if total > 0 else 0.0
+
+        return GraduationResult(
+            ready=len(blocking) == 0,
+            from_tier=from_tier,
+            to_tier=target_tier,
+            checklist=checklist,
+            blocking_items=blocking,
+            advisory_items=advisory,
+            overall_readiness=readiness,
+        )
+
+    def get_criteria(self, from_tier: ToolTier, to_tier: ToolTier) -> list[dict[str, Any]]:
+        """Get the raw criteria config for a transition."""
+        return list(self._rubrics.get((from_tier, to_tier), []))

--- a/registry/graduation/tiers.py
+++ b/registry/graduation/tiers.py
@@ -1,0 +1,84 @@
+"""Graduation tier model definitions.
+
+Defines the formal tier hierarchy (T0-T3) and the requirements
+associated with each tier transition.
+
+Tier overview:
+  T0 (Personal)  — single-user tool, no requirements
+  T1 (Shared)    — 2+ users, basic docs, no red-tier security issues
+  T2 (Team)      — team tool, quality score > 0.7, tests, tech owner
+  T3 (Critical)  — production tool, full test coverage, security review, SLA
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from shared.models import ToolTier
+
+
+@dataclass
+class TierDefinition:
+    """Definition of a single graduation tier."""
+
+    tier: ToolTier
+    label: str
+    description: str
+    support_level: str
+    monitoring: str
+
+
+# Canonical tier definitions
+TIER_DEFINITIONS: dict[ToolTier, TierDefinition] = {
+    ToolTier.T0: TierDefinition(
+        tier=ToolTier.T0,
+        label="Personal",
+        description="Any tool used by a single person.",
+        support_level="None — user is responsible.",
+        monitoring="Scorecard data collected silently.",
+    ),
+    ToolTier.T1: TierDefinition(
+        tier=ToolTier.T1,
+        label="Shared (Registered)",
+        description="Tool used by 2+ people or flagged for growing complexity.",
+        support_level="Listed in catalog, basic docs expected.",
+        monitoring="Scorecard data visible in dashboard.",
+    ),
+    ToolTier.T2: TierDefinition(
+        tier=ToolTier.T2,
+        label="Team (Owned)",
+        description="Tool used by a team or tied to a business process.",
+        support_level="Assigned tech owner, code reviewed, tests required.",
+        monitoring="Quality trends tracked, alerts on regression.",
+    ),
+    ToolTier.T3: TierDefinition(
+        tier=ToolTier.T3,
+        label="Critical (Production)",
+        description="Tool that business operations depend on.",
+        support_level="Full production standards, CI/CD, monitoring, SLA.",
+        monitoring="Full observability, alerting, on-call rotation.",
+    ),
+}
+
+
+# Ordered transitions (each tuple is from_tier, to_tier)
+VALID_TRANSITIONS: list[tuple[ToolTier, ToolTier]] = [
+    (ToolTier.T0, ToolTier.T1),
+    (ToolTier.T1, ToolTier.T2),
+    (ToolTier.T2, ToolTier.T3),
+]
+
+
+def is_valid_transition(from_tier: ToolTier, to_tier: ToolTier) -> bool:
+    """Check if a tier transition is valid (must be one step up)."""
+    return (from_tier, to_tier) in VALID_TRANSITIONS
+
+
+def get_tier_definition(tier: ToolTier) -> TierDefinition:
+    """Get the definition for a tier."""
+    return TIER_DEFINITIONS[tier]
+
+
+def tier_index(tier: ToolTier) -> int:
+    """Get the numeric index of a tier (T0=0, T1=1, etc.)."""
+    return list(ToolTier).index(tier)

--- a/tests/registry/test_graduation.py
+++ b/tests/registry/test_graduation.py
@@ -1,0 +1,497 @@
+"""Tests for graduation tier model and rubrics."""
+
+from shared.models import ScorecardSummary, ToolRegistryEntry, ToolTier
+
+from registry.graduation.rubrics import (
+    ChecklistItem,
+    GraduationResult,
+    GraduationRubric,
+)
+from registry.graduation.tiers import (
+    TIER_DEFINITIONS,
+    VALID_TRANSITIONS,
+    get_tier_definition,
+    is_valid_transition,
+    tier_index,
+)
+
+
+# --- Helpers ---
+
+
+def _make_tool(
+    name: str = "test-tool",
+    tier: ToolTier = ToolTier.T0,
+    description: str = "",
+    users: list[str] | None = None,
+    tech_owner: str | None = None,
+    composite: float = 0.0,
+    scores: dict[str, float] | None = None,
+    red_flags: int = 0,
+    source_path: str = "",
+    metadata: dict | None = None,
+) -> ToolRegistryEntry:
+    return ToolRegistryEntry(
+        name=name,
+        tier=tier,
+        description=description,
+        users=users or [],
+        tech_owner=tech_owner,
+        source_path=source_path,
+        scorecard=ScorecardSummary(
+            latest_composite=composite,
+            latest_scores=scores or {},
+            red_flags=red_flags,
+        ),
+        metadata=metadata or {},
+    )
+
+
+# --- Tier Definitions ---
+
+
+class TestTierDefinitions:
+    def test_all_tiers_defined(self):
+        for tier in ToolTier:
+            assert tier in TIER_DEFINITIONS
+
+    def test_get_tier_definition(self):
+        t0 = get_tier_definition(ToolTier.T0)
+        assert t0.label == "Personal"
+        assert t0.tier == ToolTier.T0
+
+    def test_t3_is_critical(self):
+        t3 = get_tier_definition(ToolTier.T3)
+        assert "Critical" in t3.label
+        assert "production" in t3.description.lower() or "business" in t3.description.lower()
+
+    def test_tier_index_ordering(self):
+        assert tier_index(ToolTier.T0) < tier_index(ToolTier.T1)
+        assert tier_index(ToolTier.T1) < tier_index(ToolTier.T2)
+        assert tier_index(ToolTier.T2) < tier_index(ToolTier.T3)
+
+
+# --- Valid Transitions ---
+
+
+class TestTransitions:
+    def test_valid_transitions(self):
+        assert is_valid_transition(ToolTier.T0, ToolTier.T1)
+        assert is_valid_transition(ToolTier.T1, ToolTier.T2)
+        assert is_valid_transition(ToolTier.T2, ToolTier.T3)
+
+    def test_skip_transition_invalid(self):
+        assert not is_valid_transition(ToolTier.T0, ToolTier.T2)
+        assert not is_valid_transition(ToolTier.T0, ToolTier.T3)
+        assert not is_valid_transition(ToolTier.T1, ToolTier.T3)
+
+    def test_downgrade_invalid(self):
+        assert not is_valid_transition(ToolTier.T1, ToolTier.T0)
+        assert not is_valid_transition(ToolTier.T3, ToolTier.T0)
+
+    def test_same_tier_invalid(self):
+        assert not is_valid_transition(ToolTier.T0, ToolTier.T0)
+        assert not is_valid_transition(ToolTier.T2, ToolTier.T2)
+
+    def test_all_valid_transitions_listed(self):
+        assert len(VALID_TRANSITIONS) == 3
+
+
+# --- T0 → T1 Rubric ---
+
+
+class TestT0ToT1:
+    def setup_method(self):
+        self.rubric = GraduationRubric()
+
+    def test_ready_tool_passes(self):
+        tool = _make_tool(
+            tier=ToolTier.T0,
+            description="A useful tool for data processing",
+            users=["alice", "bob"],
+            source_path="tools/data.py",
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T1)
+        assert result.ready
+        assert result.overall_readiness == 1.0
+        assert len(result.blocking_items) == 0
+
+    def test_no_description_blocks(self):
+        tool = _make_tool(
+            tier=ToolTier.T0,
+            description="",
+            users=["alice", "bob"],
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T1)
+        assert not result.ready
+        assert any("description" in b.requirement.lower() for b in result.blocking_items)
+
+    def test_single_user_blocks(self):
+        tool = _make_tool(
+            tier=ToolTier.T0,
+            description="A tool",
+            users=["alice"],
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T1)
+        assert not result.ready
+        assert any("user" in b.requirement.lower() for b in result.blocking_items)
+
+    def test_red_flags_block(self):
+        tool = _make_tool(
+            tier=ToolTier.T0,
+            description="A tool",
+            users=["alice", "bob"],
+            red_flags=1,
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T1)
+        assert not result.ready
+
+    def test_missing_source_path_is_advisory(self):
+        tool = _make_tool(
+            tier=ToolTier.T0,
+            description="A tool",
+            users=["alice", "bob"],
+            source_path="",
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T1)
+        # Source path is advisory (non-blocking), so tool should still be ready
+        assert result.ready
+        assert len(result.advisory_items) == 1
+        assert "source" in result.advisory_items[0].requirement.lower()
+
+
+# --- T1 → T2 Rubric ---
+
+
+class TestT1ToT2:
+    def setup_method(self):
+        self.rubric = GraduationRubric()
+
+    def test_ready_tool_passes(self):
+        tool = _make_tool(
+            tier=ToolTier.T1,
+            description="Team tool",
+            users=["alice", "bob", "charlie"],
+            tech_owner="dave",
+            composite=0.8,
+            scores={"testability": 0.7},
+            metadata={"dependencies_pinned": True, "code_reviewed": True},
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T2)
+        assert result.ready
+        assert len(result.blocking_items) == 0
+
+    def test_low_score_blocks(self):
+        tool = _make_tool(
+            tier=ToolTier.T1,
+            description="Team tool",
+            users=["alice", "bob"],
+            tech_owner="dave",
+            composite=0.5,
+            scores={"testability": 0.6},
+            metadata={"dependencies_pinned": True},
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T2)
+        assert not result.ready
+        assert any("score" in b.requirement.lower() for b in result.blocking_items)
+
+    def test_no_tech_owner_blocks(self):
+        tool = _make_tool(
+            tier=ToolTier.T1,
+            composite=0.8,
+            scores={"testability": 0.7},
+            metadata={"dependencies_pinned": True},
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T2)
+        assert not result.ready
+        assert any("tech owner" in b.requirement.lower() for b in result.blocking_items)
+
+    def test_no_test_coverage_blocks(self):
+        tool = _make_tool(
+            tier=ToolTier.T1,
+            tech_owner="dave",
+            composite=0.8,
+            scores={"testability": 0.3},
+            metadata={"dependencies_pinned": True},
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T2)
+        assert not result.ready
+        assert any("test" in b.requirement.lower() for b in result.blocking_items)
+
+    def test_unpinned_deps_block(self):
+        tool = _make_tool(
+            tier=ToolTier.T1,
+            tech_owner="dave",
+            composite=0.8,
+            scores={"testability": 0.7},
+            metadata={"dependencies_pinned": False},
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T2)
+        assert not result.ready
+
+    def test_code_review_is_advisory(self):
+        tool = _make_tool(
+            tier=ToolTier.T1,
+            tech_owner="dave",
+            composite=0.8,
+            scores={"testability": 0.7},
+            metadata={"dependencies_pinned": True, "code_reviewed": False},
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T2)
+        # Code review is advisory, not blocking
+        assert result.ready
+        assert len(result.advisory_items) == 1
+
+
+# --- T2 → T3 Rubric ---
+
+
+class TestT2ToT3:
+    def setup_method(self):
+        self.rubric = GraduationRubric()
+
+    def test_ready_tool_passes(self):
+        tool = _make_tool(
+            tier=ToolTier.T2,
+            users=["a", "b", "c"],
+            composite=0.9,
+            scores={"testability": 0.9},
+            metadata={
+                "security_reviewed": True,
+                "error_handling": True,
+                "rollback_plan": True,
+                "monitoring_configured": True,
+                "knowledge_transfer": True,
+            },
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T3)
+        assert result.ready
+        assert len(result.blocking_items) == 0
+
+    def test_missing_security_review_blocks(self):
+        tool = _make_tool(
+            tier=ToolTier.T2,
+            composite=0.9,
+            scores={"testability": 0.9},
+            metadata={
+                "error_handling": True,
+                "rollback_plan": True,
+                "monitoring_configured": True,
+                "knowledge_transfer": True,
+            },
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T3)
+        assert not result.ready
+        assert any("security" in b.requirement.lower() for b in result.blocking_items)
+
+    def test_low_test_coverage_blocks(self):
+        tool = _make_tool(
+            tier=ToolTier.T2,
+            composite=0.9,
+            scores={"testability": 0.5},
+            metadata={
+                "security_reviewed": True,
+                "error_handling": True,
+                "rollback_plan": True,
+                "monitoring_configured": True,
+                "knowledge_transfer": True,
+            },
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T3)
+        assert not result.ready
+
+    def test_missing_monitoring_blocks(self):
+        tool = _make_tool(
+            tier=ToolTier.T2,
+            composite=0.9,
+            scores={"testability": 0.9},
+            metadata={
+                "security_reviewed": True,
+                "error_handling": True,
+                "rollback_plan": True,
+                "knowledge_transfer": True,
+            },
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T3)
+        assert not result.ready
+
+    def test_high_composite_required(self):
+        tool = _make_tool(
+            tier=ToolTier.T2,
+            composite=0.7,  # Below 0.8 threshold for T3
+            scores={"testability": 0.9},
+            metadata={
+                "security_reviewed": True,
+                "error_handling": True,
+                "rollback_plan": True,
+                "monitoring_configured": True,
+                "knowledge_transfer": True,
+            },
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T3)
+        assert not result.ready
+
+    def test_min_users_is_advisory(self):
+        tool = _make_tool(
+            tier=ToolTier.T2,
+            users=["alice"],  # Only 1, below advisory threshold of 3
+            composite=0.9,
+            scores={"testability": 0.9},
+            metadata={
+                "security_reviewed": True,
+                "error_handling": True,
+                "rollback_plan": True,
+                "monitoring_configured": True,
+                "knowledge_transfer": True,
+            },
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T3)
+        assert result.ready  # Advisory only
+        assert len(result.advisory_items) == 1
+
+
+# --- Invalid Transitions ---
+
+
+class TestInvalidTransitions:
+    def setup_method(self):
+        self.rubric = GraduationRubric()
+
+    def test_skip_tier_rejected(self):
+        tool = _make_tool(tier=ToolTier.T0)
+        result = self.rubric.evaluate(tool, ToolTier.T2)
+        assert not result.ready
+        assert "transition" in result.checklist[0].requirement.lower()
+
+    def test_downgrade_rejected(self):
+        tool = _make_tool(tier=ToolTier.T2)
+        result = self.rubric.evaluate(tool, ToolTier.T1)
+        assert not result.ready
+
+    def test_same_tier_rejected(self):
+        tool = _make_tool(tier=ToolTier.T1)
+        result = self.rubric.evaluate(tool, ToolTier.T1)
+        assert not result.ready
+
+
+# --- Readiness Score ---
+
+
+class TestReadiness:
+    def setup_method(self):
+        self.rubric = GraduationRubric()
+
+    def test_full_readiness(self):
+        tool = _make_tool(
+            tier=ToolTier.T0,
+            description="A tool",
+            users=["alice", "bob"],
+            source_path="tools/data.py",
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T1)
+        assert result.overall_readiness == 1.0
+
+    def test_partial_readiness(self):
+        tool = _make_tool(
+            tier=ToolTier.T0,
+            description="",
+            users=["alice"],
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T1)
+        assert 0.0 < result.overall_readiness < 1.0
+
+    def test_zero_readiness(self):
+        tool = _make_tool(
+            tier=ToolTier.T0,
+            description="",
+            users=[],
+            red_flags=3,
+        )
+        result = self.rubric.evaluate(tool, ToolTier.T1)
+        assert result.overall_readiness == 0.0
+
+
+# --- Custom Config ---
+
+
+class TestCustomConfig:
+    def test_override_criteria(self):
+        custom = {
+            (ToolTier.T0, ToolTier.T1): [
+                {
+                    "requirement": "Must have 5 users",
+                    "check": "min_users",
+                    "blocking": True,
+                    "params": {"min": 5},
+                },
+            ],
+        }
+        rubric = GraduationRubric(config_overrides=custom)
+        tool = _make_tool(tier=ToolTier.T0, users=["a", "b"])
+        result = rubric.evaluate(tool, ToolTier.T1)
+        assert not result.ready
+
+    def test_custom_does_not_affect_other_transitions(self):
+        custom = {
+            (ToolTier.T0, ToolTier.T1): [
+                {
+                    "requirement": "Custom",
+                    "check": "has_description",
+                    "blocking": True,
+                },
+            ],
+        }
+        rubric = GraduationRubric(config_overrides=custom)
+        # T1→T2 should still use defaults
+        criteria = rubric.get_criteria(ToolTier.T1, ToolTier.T2)
+        assert len(criteria) > 1
+
+    def test_get_criteria_returns_copy(self):
+        rubric = GraduationRubric()
+        criteria = rubric.get_criteria(ToolTier.T0, ToolTier.T1)
+        criteria.clear()
+        # Original should be unaffected
+        assert len(rubric.get_criteria(ToolTier.T0, ToolTier.T1)) > 0
+
+    def test_unknown_check_handled(self):
+        custom = {
+            (ToolTier.T0, ToolTier.T1): [
+                {
+                    "requirement": "Mystery check",
+                    "check": "does_not_exist",
+                    "blocking": True,
+                },
+            ],
+        }
+        rubric = GraduationRubric(config_overrides=custom)
+        tool = _make_tool(tier=ToolTier.T0)
+        result = rubric.evaluate(tool, ToolTier.T1)
+        assert not result.ready
+        assert "Unknown" in result.checklist[0].details
+
+
+# --- GraduationResult ---
+
+
+class TestGraduationResult:
+    def test_result_fields(self):
+        result = GraduationResult(
+            ready=True,
+            from_tier=ToolTier.T0,
+            to_tier=ToolTier.T1,
+            overall_readiness=1.0,
+        )
+        assert result.ready
+        assert result.from_tier == ToolTier.T0
+        assert result.to_tier == ToolTier.T1
+
+    def test_checklist_item_fields(self):
+        item = ChecklistItem(
+            requirement="Has description",
+            met=True,
+            details="Looks good",
+            blocking=True,
+        )
+        assert item.requirement == "Has description"
+        assert item.met
+        assert item.blocking


### PR DESCRIPTION
## Summary
- Defines the 4-tier graduation model in `registry/graduation/tiers.py`: T0 (Personal), T1 (Shared), T2 (Team), T3 (Critical) with labels, descriptions, and support levels
- Implements `GraduationRubric` in `registry/graduation/rubrics.py` with data-driven criteria for each transition (T0→T1, T1→T2, T2→T3)
- 15 check functions evaluate tool readiness: description, users, red flags, composite score, tech owner, test coverage, dependencies, security review, monitoring, etc.
- Criteria are configurable via `config_overrides` dict; each item is blocking or advisory
- 38 tests covering all transitions, blocking/advisory classification, readiness scoring, custom configs, and edge cases

## Test plan
- [x] 38 tests passing for graduation tiers and rubrics
- [x] Lint clean (ruff check)
- [x] Format clean (ruff format)

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)