### PR TITLE
feat: YAML-based tool catalog with CRUD, promotion, and search

### DIFF
--- a/registry/catalog/catalog.py
+++ b/registry/catalog/catalog.py
@@ -1,0 +1,272 @@
+"""Tool catalog — persistent YAML-based registry for T1+ tools.
+
+Provides CRUD operations, tier promotion with graduation history,
+scorecard updates, and search/filter capabilities.
+
+Storage: each tool gets a YAML file in the catalog data directory,
+keyed by slug (e.g. ``data/expense-categorizer.yaml``).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from shared.models import (
+    GraduationEvent,
+    ScorecardSummary,
+    ScoreResult,
+    ToolRegistryEntry,
+    ToolTier,
+)
+
+
+def _slugify(name: str) -> str:
+    """Convert a tool name to a URL-safe slug."""
+    slug = name.lower().strip()
+    slug = re.sub(r"[^a-z0-9]+", "-", slug)
+    slug = slug.strip("-")
+    return slug
+
+
+class ToolCatalog:
+    """YAML-backed tool catalog with CRUD, promotion, and search.
+
+    Args:
+        data_dir: Directory to store tool YAML files.
+    """
+
+    def __init__(self, data_dir: str | Path | None = None) -> None:
+        if data_dir is None:
+            data_dir = Path("./registry/catalog/data")
+        self._data_dir = Path(data_dir)
+        self._data_dir.mkdir(parents=True, exist_ok=True)
+
+    def _tool_path(self, slug: str) -> Path:
+        """Get the YAML file path for a tool slug."""
+        return self._data_dir / f"{slug}.yaml"
+
+    def _save(self, tool: ToolRegistryEntry) -> None:
+        """Save a tool entry to YAML."""
+        data = tool.model_dump(mode="json")
+        path = self._tool_path(tool.slug)
+        with open(path, "w") as f:
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+    def _load(self, slug: str) -> ToolRegistryEntry | None:
+        """Load a tool entry from YAML."""
+        path = self._tool_path(slug)
+        if not path.exists():
+            return None
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        if not data:
+            return None
+        return ToolRegistryEntry.model_validate(data)
+
+    def register(self, tool: ToolRegistryEntry) -> str:
+        """Register a new tool. Returns the slug.
+
+        If no slug is set, one is generated from the name.
+
+        Raises:
+            ValueError: If a tool with the same slug already exists.
+        """
+        if not tool.slug:
+            tool = tool.model_copy(update={"slug": _slugify(tool.name)})
+
+        if self._tool_path(tool.slug).exists():
+            raise ValueError(f"Tool '{tool.slug}' already exists.")
+
+        self._save(tool)
+        return tool.slug
+
+    def get(self, slug: str) -> ToolRegistryEntry | None:
+        """Get a tool by slug. Returns None if not found."""
+        return self._load(slug)
+
+    def list(
+        self,
+        *,
+        tier: ToolTier | None = None,
+        owner: str | None = None,
+        tag: str | None = None,
+    ) -> list[ToolRegistryEntry]:
+        """List tools with optional filters.
+
+        Args:
+            tier: Filter by tier.
+            owner: Filter by tech owner.
+            tag: Filter by tag.
+
+        Returns:
+            List of matching tools, sorted by name.
+        """
+        tools: list[ToolRegistryEntry] = []
+
+        for path in sorted(self._data_dir.glob("*.yaml")):
+            with open(path) as f:
+                data = yaml.safe_load(f)
+            if not data:
+                continue
+
+            tool = ToolRegistryEntry.model_validate(data)
+
+            if tier is not None and tool.tier != tier:
+                continue
+            if owner is not None and tool.tech_owner != owner:
+                continue
+            if tag is not None and tag not in tool.tags:
+                continue
+
+            tools.append(tool)
+
+        return sorted(tools, key=lambda t: t.name.lower())
+
+    def update(self, slug: str, updates: dict[str, Any]) -> ToolRegistryEntry:
+        """Update tool metadata.
+
+        Args:
+            slug: Tool slug.
+            updates: Dictionary of fields to update.
+
+        Returns:
+            Updated tool entry.
+
+        Raises:
+            KeyError: If tool not found.
+        """
+        tool = self._load(slug)
+        if tool is None:
+            raise KeyError(f"Tool '{slug}' not found.")
+
+        tool = tool.model_copy(update=updates)
+        self._save(tool)
+        return tool
+
+    def delete(self, slug: str) -> bool:
+        """Delete a tool from the catalog.
+
+        Returns True if deleted, False if not found.
+        """
+        path = self._tool_path(slug)
+        if not path.exists():
+            return False
+        path.unlink()
+        return True
+
+    def promote(
+        self,
+        slug: str,
+        target_tier: ToolTier,
+        reason: str = "",
+        approved_by: str = "",
+    ) -> ToolRegistryEntry:
+        """Promote a tool to a higher tier. Records graduation history.
+
+        Args:
+            slug: Tool slug.
+            target_tier: The tier to promote to.
+            reason: Reason for promotion.
+            approved_by: Who approved the promotion.
+
+        Returns:
+            Updated tool entry.
+
+        Raises:
+            KeyError: If tool not found.
+            ValueError: If transition is invalid.
+        """
+        tool = self._load(slug)
+        if tool is None:
+            raise KeyError(f"Tool '{slug}' not found.")
+
+        from registry.graduation.tiers import is_valid_transition
+
+        if not is_valid_transition(tool.tier, target_tier):
+            raise ValueError(
+                f"Cannot promote from {tool.tier.value} to {target_tier.value}. "
+                "Must be one step up."
+            )
+
+        event = GraduationEvent(
+            from_tier=tool.tier,
+            to_tier=target_tier,
+            reason=reason,
+            approved_by=approved_by,
+        )
+
+        new_history = list(tool.graduation_history) + [event]
+        tool = tool.model_copy(
+            update={
+                "tier": target_tier,
+                "graduation_history": new_history,
+            }
+        )
+        self._save(tool)
+        return tool
+
+    def update_scorecard(self, slug: str, score_result: ScoreResult) -> None:
+        """Update a tool's scorecard summary with the latest score.
+
+        Args:
+            slug: Tool slug.
+            score_result: The latest score result.
+
+        Raises:
+            KeyError: If tool not found.
+        """
+        tool = self._load(slug)
+        if tool is None:
+            raise KeyError(f"Tool '{slug}' not found.")
+
+        # Build latest_scores from dimension scores
+        latest_scores = {ds.dimension.value: ds.score for ds in score_result.dimension_scores}
+
+        # Determine trend
+        prev = tool.scorecard.latest_composite
+        new = score_result.composite_score
+        if new > prev + 0.05:
+            trend = "improving"
+        elif new < prev - 0.05:
+            trend = "declining"
+        else:
+            trend = "stable"
+
+        new_scorecard = ScorecardSummary(
+            latest_composite=new,
+            latest_scores=latest_scores,
+            trend=trend,
+            total_scores=tool.scorecard.total_scores + 1,
+            red_flags=tool.scorecard.red_flags,
+        )
+
+        tool = tool.model_copy(update={"scorecard": new_scorecard})
+        self._save(tool)
+
+    def search(self, query: str) -> list[ToolRegistryEntry]:
+        """Search tools by name or description.
+
+        Args:
+            query: Search string (case-insensitive substring match).
+
+        Returns:
+            List of matching tools.
+        """
+        query_lower = query.lower()
+        results: list[ToolRegistryEntry] = []
+
+        for path in sorted(self._data_dir.glob("*.yaml")):
+            with open(path) as f:
+                data = yaml.safe_load(f)
+            if not data:
+                continue
+
+            tool = ToolRegistryEntry.model_validate(data)
+            if query_lower in tool.name.lower() or query_lower in tool.description.lower():
+                results.append(tool)
+
+        return sorted(results, key=lambda t: t.name.lower())

--- a/tests/registry/test_catalog.py
+++ b/tests/registry/test_catalog.py
@@ -1,0 +1,400 @@
+"""Tests for tool catalog CRUD and promotion."""
+
+import pytest
+
+from shared.models import (
+    Dimension,
+    DimensionScore,
+    ScorecardSummary,
+    ScoringMethod,
+    ScoreResult,
+    ToolRegistryEntry,
+    ToolTier,
+)
+
+from registry.catalog.catalog import ToolCatalog, _slugify
+
+
+# --- Helpers ---
+
+
+def _make_tool(
+    name: str = "Test Tool",
+    tier: ToolTier = ToolTier.T0,
+    description: str = "A test tool",
+    users: list[str] | None = None,
+    tags: list[str] | None = None,
+    tech_owner: str | None = None,
+) -> ToolRegistryEntry:
+    return ToolRegistryEntry(
+        name=name,
+        tier=tier,
+        description=description,
+        users=users or ["alice"],
+        tags=tags or [],
+        tech_owner=tech_owner,
+    )
+
+
+# --- Slugify ---
+
+
+class TestSlugify:
+    def test_basic_name(self):
+        assert _slugify("My Tool") == "my-tool"
+
+    def test_special_chars(self):
+        assert _slugify("Expense Categorizer (v2)") == "expense-categorizer-v2"
+
+    def test_leading_trailing(self):
+        assert _slugify("  My Tool  ") == "my-tool"
+
+    def test_multiple_spaces(self):
+        assert _slugify("My   Great   Tool") == "my-great-tool"
+
+    def test_already_slug(self):
+        assert _slugify("my-tool") == "my-tool"
+
+
+# --- Register ---
+
+
+class TestRegister:
+    def test_register_new_tool(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        tool = _make_tool(name="Expense Categorizer")
+        slug = catalog.register(tool)
+        assert slug == "expense-categorizer"
+        assert (tmp_path / "expense-categorizer.yaml").exists()
+
+    def test_register_with_explicit_slug(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        tool = _make_tool(name="My Tool")
+        tool = tool.model_copy(update={"slug": "custom-slug"})
+        slug = catalog.register(tool)
+        assert slug == "custom-slug"
+
+    def test_register_duplicate_raises(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        tool = _make_tool(name="My Tool")
+        catalog.register(tool)
+        with pytest.raises(ValueError, match="already exists"):
+            catalog.register(tool)
+
+    def test_register_returns_slug(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        tool = _make_tool(name="Data Pipeline")
+        slug = catalog.register(tool)
+        assert slug == "data-pipeline"
+
+
+# --- Get ---
+
+
+class TestGet:
+    def test_get_existing(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        tool = _make_tool(name="My Tool", description="Does stuff")
+        catalog.register(tool)
+
+        loaded = catalog.get("my-tool")
+        assert loaded is not None
+        assert loaded.name == "My Tool"
+        assert loaded.description == "Does stuff"
+
+    def test_get_nonexistent(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        assert catalog.get("nope") is None
+
+    def test_get_preserves_all_fields(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        tool = _make_tool(
+            name="Full Tool",
+            tier=ToolTier.T1,
+            users=["alice", "bob"],
+            tags=["finance", "automation"],
+            tech_owner="dave",
+        )
+        catalog.register(tool)
+
+        loaded = catalog.get("full-tool")
+        assert loaded is not None
+        assert loaded.tier == ToolTier.T1
+        assert loaded.users == ["alice", "bob"]
+        assert loaded.tags == ["finance", "automation"]
+        assert loaded.tech_owner == "dave"
+
+
+# --- List ---
+
+
+class TestList:
+    def test_list_all(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        catalog.register(_make_tool(name="Tool B"))
+        catalog.register(_make_tool(name="Tool A"))
+        catalog.register(_make_tool(name="Tool C"))
+
+        tools = catalog.list()
+        assert len(tools) == 3
+        assert tools[0].name == "Tool A"  # Sorted by name
+
+    def test_list_empty(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        assert catalog.list() == []
+
+    def test_filter_by_tier(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        catalog.register(_make_tool(name="T0 Tool", tier=ToolTier.T0))
+        catalog.register(_make_tool(name="T1 Tool", tier=ToolTier.T1))
+
+        t1_tools = catalog.list(tier=ToolTier.T1)
+        assert len(t1_tools) == 1
+        assert t1_tools[0].name == "T1 Tool"
+
+    def test_filter_by_owner(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        catalog.register(_make_tool(name="Tool A", tech_owner="alice"))
+        catalog.register(_make_tool(name="Tool B", tech_owner="bob"))
+
+        alice_tools = catalog.list(owner="alice")
+        assert len(alice_tools) == 1
+        assert alice_tools[0].tech_owner == "alice"
+
+    def test_filter_by_tag(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        catalog.register(_make_tool(name="Finance Tool", tags=["finance"]))
+        catalog.register(_make_tool(name="HR Tool", tags=["hr"]))
+
+        finance = catalog.list(tag="finance")
+        assert len(finance) == 1
+        assert finance[0].name == "Finance Tool"
+
+    def test_filter_combined(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        catalog.register(
+            _make_tool(name="A", tier=ToolTier.T1, tech_owner="alice", tags=["finance"])
+        )
+        catalog.register(_make_tool(name="B", tier=ToolTier.T1, tech_owner="bob", tags=["finance"]))
+        catalog.register(
+            _make_tool(name="C", tier=ToolTier.T2, tech_owner="alice", tags=["finance"])
+        )
+
+        results = catalog.list(tier=ToolTier.T1, owner="alice")
+        assert len(results) == 1
+        assert results[0].name == "A"
+
+
+# --- Update ---
+
+
+class TestUpdate:
+    def test_update_description(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        catalog.register(_make_tool(name="My Tool"))
+
+        updated = catalog.update("my-tool", {"description": "New description"})
+        assert updated.description == "New description"
+
+        # Persisted
+        reloaded = catalog.get("my-tool")
+        assert reloaded is not None
+        assert reloaded.description == "New description"
+
+    def test_update_tech_owner(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        catalog.register(_make_tool(name="My Tool"))
+
+        updated = catalog.update("my-tool", {"tech_owner": "bob"})
+        assert updated.tech_owner == "bob"
+
+    def test_update_nonexistent_raises(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        with pytest.raises(KeyError, match="not found"):
+            catalog.update("nope", {"description": "x"})
+
+
+# --- Delete ---
+
+
+class TestDelete:
+    def test_delete_existing(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        catalog.register(_make_tool(name="My Tool"))
+
+        assert catalog.delete("my-tool")
+        assert catalog.get("my-tool") is None
+
+    def test_delete_nonexistent(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        assert not catalog.delete("nope")
+
+
+# --- Promote ---
+
+
+class TestPromote:
+    def test_promote_t0_to_t1(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        catalog.register(_make_tool(name="My Tool", tier=ToolTier.T0))
+
+        promoted = catalog.promote("my-tool", ToolTier.T1, reason="Second user", approved_by="auto")
+        assert promoted.tier == ToolTier.T1
+        assert len(promoted.graduation_history) == 1
+        assert promoted.graduation_history[0].from_tier == ToolTier.T0
+        assert promoted.graduation_history[0].to_tier == ToolTier.T1
+        assert promoted.graduation_history[0].reason == "Second user"
+
+    def test_promote_persisted(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        catalog.register(_make_tool(name="My Tool", tier=ToolTier.T0))
+        catalog.promote("my-tool", ToolTier.T1)
+
+        reloaded = catalog.get("my-tool")
+        assert reloaded is not None
+        assert reloaded.tier == ToolTier.T1
+
+    def test_promote_invalid_transition_raises(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        catalog.register(_make_tool(name="My Tool", tier=ToolTier.T0))
+
+        with pytest.raises(ValueError, match="Cannot promote"):
+            catalog.promote("my-tool", ToolTier.T3)
+
+    def test_promote_nonexistent_raises(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        with pytest.raises(KeyError, match="not found"):
+            catalog.promote("nope", ToolTier.T1)
+
+    def test_promote_accumulates_history(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        catalog.register(_make_tool(name="My Tool", tier=ToolTier.T0))
+
+        catalog.promote("my-tool", ToolTier.T1, reason="Shared")
+        catalog.promote("my-tool", ToolTier.T2, reason="Team adoption")
+
+        tool = catalog.get("my-tool")
+        assert tool is not None
+        assert tool.tier == ToolTier.T2
+        assert len(tool.graduation_history) == 2
+
+
+# --- Update Scorecard ---
+
+
+class TestUpdateScorecard:
+    def test_update_scorecard(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        catalog.register(_make_tool(name="My Tool"))
+
+        score = ScoreResult(
+            user="alice",
+            composite_score=0.85,
+            dimension_scores=[
+                DimensionScore(
+                    dimension=Dimension.CORRECTNESS,
+                    score=0.9,
+                    method=ScoringMethod.RULE_BASED,
+                ),
+            ],
+        )
+        catalog.update_scorecard("my-tool", score)
+
+        tool = catalog.get("my-tool")
+        assert tool is not None
+        assert tool.scorecard.latest_composite == 0.85
+        assert tool.scorecard.latest_scores["correctness"] == 0.9
+        assert tool.scorecard.total_scores == 1
+
+    def test_scorecard_trend_improving(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        tool = _make_tool(name="My Tool")
+        tool = tool.model_copy(update={"scorecard": ScorecardSummary(latest_composite=0.5)})
+        catalog.register(tool)
+
+        score = ScoreResult(user="alice", composite_score=0.8)
+        catalog.update_scorecard("my-tool", score)
+
+        reloaded = catalog.get("my-tool")
+        assert reloaded is not None
+        assert reloaded.scorecard.trend == "improving"
+
+    def test_scorecard_trend_declining(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        tool = _make_tool(name="My Tool")
+        tool = tool.model_copy(update={"scorecard": ScorecardSummary(latest_composite=0.9)})
+        catalog.register(tool)
+
+        score = ScoreResult(user="alice", composite_score=0.5)
+        catalog.update_scorecard("my-tool", score)
+
+        reloaded = catalog.get("my-tool")
+        assert reloaded is not None
+        assert reloaded.scorecard.trend == "declining"
+
+    def test_scorecard_trend_stable(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        tool = _make_tool(name="My Tool")
+        tool = tool.model_copy(update={"scorecard": ScorecardSummary(latest_composite=0.8)})
+        catalog.register(tool)
+
+        score = ScoreResult(user="alice", composite_score=0.82)
+        catalog.update_scorecard("my-tool", score)
+
+        reloaded = catalog.get("my-tool")
+        assert reloaded is not None
+        assert reloaded.scorecard.trend == "stable"
+
+    def test_scorecard_increments_total(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        catalog.register(_make_tool(name="My Tool"))
+
+        for _ in range(3):
+            score = ScoreResult(user="alice", composite_score=0.7)
+            catalog.update_scorecard("my-tool", score)
+
+        tool = catalog.get("my-tool")
+        assert tool is not None
+        assert tool.scorecard.total_scores == 3
+
+    def test_scorecard_nonexistent_raises(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        score = ScoreResult(user="alice", composite_score=0.7)
+        with pytest.raises(KeyError, match="not found"):
+            catalog.update_scorecard("nope", score)
+
+
+# --- Search ---
+
+
+class TestSearch:
+    def test_search_by_name(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        catalog.register(_make_tool(name="Expense Categorizer"))
+        catalog.register(_make_tool(name="Data Pipeline"))
+
+        results = catalog.search("expense")
+        assert len(results) == 1
+        assert results[0].name == "Expense Categorizer"
+
+    def test_search_by_description(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        catalog.register(_make_tool(name="Tool A", description="Handles finance reports"))
+        catalog.register(_make_tool(name="Tool B", description="Processes HR data"))
+
+        results = catalog.search("finance")
+        assert len(results) == 1
+        assert results[0].name == "Tool A"
+
+    def test_search_case_insensitive(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        catalog.register(_make_tool(name="My Great Tool"))
+
+        results = catalog.search("GREAT")
+        assert len(results) == 1
+
+    def test_search_no_results(self, tmp_path):
+        catalog = ToolCatalog(data_dir=tmp_path)
+        catalog.register(_make_tool(name="Something"))
+
+        assert catalog.search("xyz") == []


### PR DESCRIPTION
## Summary
- Implements `ToolCatalog` in `registry/catalog/catalog.py` with full CRUD: register, get, list, update, delete
- YAML-based storage — each tool saved as a separate YAML file keyed by slug
- Promotion records graduation history and validates one-step-up transitions
- Scorecard updates with trend detection (improving/stable/declining)
- Search by name or description (case-insensitive), filter by tier/owner/tag
- Slug auto-generation from tool name via `_slugify()`
- 38 tests covering all operations, error cases, filters, and persistence

## Test plan
- [x] 38 tests passing for tool catalog
- [x] Lint clean (ruff check)
- [x] Format clean (ruff format)

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)