### PR TITLE
feat: knowledge transfer document generator for tool graduation

### DIFF
--- a/registry/workflows/knowledge_transfer.py
+++ b/registry/workflows/knowledge_transfer.py
@@ -1,0 +1,313 @@
+"""Knowledge transfer document generator.
+
+Produces a Markdown document from a tool's registry entry, source code,
+and scorecard history. Designed for tech team onboarding when a tool
+graduates to T2 or T3.
+
+All analysis is rule-based (no LLM dependency). Sections are generated
+from code inspection and scorecard data.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from shared.models import ScoreResult, ToolRegistryEntry
+from shared.storage import StorageBackend
+
+
+@staticmethod
+def _safe_parse(code: str) -> ast.Module | None:
+    """Parse code, returning None on syntax error."""
+    try:
+        return ast.parse(code)
+    except SyntaxError:
+        return None
+
+
+class CodeAnalysis:
+    """Static analysis results for a source file."""
+
+    def __init__(self, path: Path, code: str) -> None:
+        self.path = path
+        self.code = code
+        self.lines = code.splitlines()
+        self.line_count = len(self.lines)
+        self.tree = _safe_parse(code)
+
+        self.functions: list[str] = []
+        self.classes: list[str] = []
+        self.imports: list[str] = []
+        self.stdlib_imports: list[str] = []
+        self.third_party_imports: list[str] = []
+
+        if self.tree:
+            self._analyze()
+
+    def _analyze(self) -> None:
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.FunctionDef):
+                self.functions.append(node.name)
+            elif isinstance(node, ast.AsyncFunctionDef):
+                self.functions.append(f"{node.name} (async)")
+            elif isinstance(node, ast.ClassDef):
+                self.classes.append(node.name)
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    self.imports.append(alias.name)
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    self.imports.append(node.module)
+
+        # Classify imports (heuristic: dotted names with common prefixes = stdlib)
+        _STDLIB_PREFIXES = {
+            "os",
+            "sys",
+            "re",
+            "json",
+            "csv",
+            "math",
+            "datetime",
+            "pathlib",
+            "collections",
+            "itertools",
+            "functools",
+            "typing",
+            "dataclasses",
+            "enum",
+            "abc",
+            "io",
+            "logging",
+            "argparse",
+            "unittest",
+            "ast",
+            "hashlib",
+            "uuid",
+            "time",
+            "shutil",
+            "subprocess",
+            "tempfile",
+        }
+        for imp in self.imports:
+            root = imp.split(".")[0]
+            if root in _STDLIB_PREFIXES:
+                self.stdlib_imports.append(imp)
+            else:
+                self.third_party_imports.append(imp)
+
+
+class KnowledgeTransferGenerator:
+    """Generates knowledge transfer Markdown documents.
+
+    Args:
+        storage: Score storage backend for history queries.
+    """
+
+    def __init__(self, storage: StorageBackend | None = None) -> None:
+        self._storage = storage
+
+    def generate(self, tool: ToolRegistryEntry) -> str:
+        """Generate a knowledge transfer document as Markdown.
+
+        Args:
+            tool: The tool registry entry.
+
+        Returns:
+            Markdown string.
+        """
+        sections = [
+            self._header(tool),
+            self._overview(tool),
+            self._architecture(tool),
+            self._quality_profile(tool),
+            self._risk_assessment(tool),
+            self._maintenance_guide(tool),
+            self._scorecard_history(tool),
+        ]
+        return "\n\n".join(s for s in sections if s) + "\n"
+
+    def _header(self, tool: ToolRegistryEntry) -> str:
+        return f"# Knowledge Transfer: {tool.name}"
+
+    def _overview(self, tool: ToolRegistryEntry) -> str:
+        lines = ["## Overview", ""]
+        lines.append(f"- **Purpose:** {tool.description or 'Not documented'}")
+        lines.append(f"- **Created by:** {tool.created_by or 'Unknown'}")
+        lines.append(f"- **Current tier:** {tool.tier.value}")
+        lines.append(f"- **Tech owner:** {tool.tech_owner or 'Unassigned'}")
+
+        if tool.users:
+            lines.append(f"- **Users:** {', '.join(tool.users)}")
+        if tool.tags:
+            lines.append(f"- **Tags:** {', '.join(tool.tags)}")
+
+        return "\n".join(lines)
+
+    def _architecture(self, tool: ToolRegistryEntry) -> str:
+        lines = ["## Architecture", ""]
+
+        analysis = self._analyze_source(tool)
+        if analysis is None:
+            lines.append("*Source code not available for analysis.*")
+            return "\n".join(lines)
+
+        lines.append(f"- **Source:** `{tool.source_path}`")
+        lines.append(f"- **Lines of code:** {analysis.line_count}")
+
+        if analysis.classes:
+            lines.append(f"- **Classes:** {', '.join(analysis.classes)}")
+        if analysis.functions:
+            func_display = analysis.functions[:10]
+            suffix = (
+                f" (+{len(analysis.functions) - 10} more)" if len(analysis.functions) > 10 else ""
+            )
+            lines.append(f"- **Functions:** {', '.join(func_display)}{suffix}")
+
+        if analysis.third_party_imports:
+            lines.append("")
+            lines.append("### Dependencies")
+            lines.append("")
+            for imp in sorted(set(analysis.third_party_imports)):
+                lines.append(f"- `{imp}`")
+
+        return "\n".join(lines)
+
+    def _quality_profile(self, tool: ToolRegistryEntry) -> str:
+        lines = ["## Quality Profile", ""]
+        sc = tool.scorecard
+
+        lines.append(f"- **Latest composite score:** {sc.latest_composite:.2f}")
+        lines.append(f"- **Trend:** {sc.trend}")
+        lines.append(f"- **Total scoring events:** {sc.total_scores}")
+
+        if sc.latest_scores:
+            sorted_dims = sorted(sc.latest_scores.items(), key=lambda x: x[1], reverse=True)
+            if len(sorted_dims) >= 2:
+                top = sorted_dims[:2]
+                bottom = sorted_dims[-2:]
+                lines.append(
+                    f"- **Strongest dimensions:** "
+                    f"{top[0][0]} ({top[0][1]:.2f}), {top[1][0]} ({top[1][1]:.2f})"
+                )
+                lines.append(
+                    f"- **Areas for improvement:** "
+                    f"{bottom[0][0]} ({bottom[0][1]:.2f}), {bottom[1][0]} ({bottom[1][1]:.2f})"
+                )
+
+        if sc.red_flags > 0:
+            lines.append(f"- **Security findings:** {sc.red_flags} red-tier issue(s)")
+        else:
+            lines.append("- **Security findings:** None")
+
+        return "\n".join(lines)
+
+    def _risk_assessment(self, tool: ToolRegistryEntry) -> str:
+        lines = ["## Risk Assessment", ""]
+        sc = tool.scorecard
+
+        # Test coverage
+        test_score = sc.latest_scores.get("testability", 0.0)
+        if test_score >= 0.8:
+            lines.append("- **Test coverage:** Comprehensive")
+        elif test_score >= 0.5:
+            lines.append("- **Test coverage:** Basic")
+        else:
+            lines.append("- **Test coverage:** Insufficient or absent")
+
+        # Bus factor
+        bus_factor = len(tool.users)
+        if bus_factor <= 1:
+            lines.append("- **Bus factor:** 1 (high risk — single point of knowledge)")
+        else:
+            lines.append(f"- **Bus factor:** {bus_factor}")
+
+        # Complexity from source
+        analysis = self._analyze_source(tool)
+        if analysis:
+            if analysis.line_count > 500:
+                lines.append(f"- **Complexity:** High ({analysis.line_count} lines)")
+            elif analysis.line_count > 200:
+                lines.append(f"- **Complexity:** Moderate ({analysis.line_count} lines)")
+            else:
+                lines.append(f"- **Complexity:** Low ({analysis.line_count} lines)")
+
+            # Single point of failure
+            if len(analysis.classes) <= 1 and len(analysis.functions) > 10:
+                lines.append("- **Single point of failure:** Yes — many functions in one file")
+
+        return "\n".join(lines)
+
+    def _maintenance_guide(self, tool: ToolRegistryEntry) -> str:
+        lines = ["## Maintenance Guide", ""]
+
+        if tool.source_path:
+            lines.append(f"- **Source location:** `{tool.source_path}`")
+
+        # How to run
+        analysis = self._analyze_source(tool)
+        if analysis:
+            has_main = any("__main__" in line for line in analysis.lines)
+            if has_main:
+                lines.append(f"- **How to run:** `python {tool.source_path}`")
+            has_cli = any("argparse" in imp for imp in analysis.imports)
+            if has_cli:
+                lines.append(f"- **CLI:** `python {tool.source_path} --help`")
+
+        # Known issues from scorecard
+        sc = tool.scorecard
+        weak_dims = [(dim, score) for dim, score in sc.latest_scores.items() if score < 0.5]
+        if weak_dims:
+            lines.append("")
+            lines.append("### Known Issues")
+            lines.append("")
+            for dim, score in weak_dims:
+                lines.append(f"- **{dim}** score is low ({score:.2f}) — needs improvement")
+
+        return "\n".join(lines)
+
+    def _scorecard_history(self, tool: ToolRegistryEntry) -> str:
+        lines = ["## Scorecard History", ""]
+
+        if not self._storage:
+            lines.append("*Score history not available (no storage backend).*")
+            return "\n".join(lines)
+
+        scores = self._get_tool_scores(tool)
+        if not scores:
+            lines.append("*No scoring events recorded.*")
+            return "\n".join(lines)
+
+        # Summary table
+        lines.append("| Date | Score | User |")
+        lines.append("|------|-------|------|")
+        for s in sorted(scores, key=lambda x: x.timestamp, reverse=True)[:20]:
+            date_str = s.timestamp.strftime("%Y-%m-%d")
+            lines.append(f"| {date_str} | {s.composite_score:.2f} | {s.user} |")
+
+        if len(scores) > 20:
+            lines.append(f"| ... | *{len(scores) - 20} more* | |")
+
+        return "\n".join(lines)
+
+    def _analyze_source(self, tool: ToolRegistryEntry) -> CodeAnalysis | None:
+        """Analyze the tool's source code if available."""
+        if not tool.source_path:
+            return None
+        path = Path(tool.source_path)
+        if not path.exists() or not path.is_file():
+            return None
+        try:
+            code = path.read_text()
+        except Exception:
+            return None
+        return CodeAnalysis(path, code)
+
+    def _get_tool_scores(self, tool: ToolRegistryEntry) -> list[ScoreResult]:
+        """Get scoring history for a tool."""
+        if not self._storage:
+            return []
+        all_scores = self._storage.query()
+        if not tool.source_path:
+            return []
+        return [s for s in all_scores if any(tool.source_path in f for f in s.files_touched)]

--- a/tests/registry/test_knowledge_transfer.py
+++ b/tests/registry/test_knowledge_transfer.py
@@ -1,0 +1,356 @@
+"""Tests for knowledge transfer document generator."""
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+from shared.models import ScorecardSummary, ScoreResult, ToolRegistryEntry, ToolTier
+
+from registry.workflows.knowledge_transfer import (
+    CodeAnalysis,
+    KnowledgeTransferGenerator,
+)
+
+
+# --- Helpers ---
+
+
+def _make_tool(
+    name: str = "Expense Categorizer",
+    tier: ToolTier = ToolTier.T2,
+    description: str = "Categorizes expense reports by department",
+    created_by: str = "jane",
+    tech_owner: str = "dave",
+    users: list[str] | None = None,
+    tags: list[str] | None = None,
+    source_path: str = "",
+    composite: float = 0.72,
+    scores: dict[str, float] | None = None,
+    red_flags: int = 0,
+    total_scores: int = 23,
+    trend: str = "improving",
+) -> ToolRegistryEntry:
+    return ToolRegistryEntry(
+        name=name,
+        tier=tier,
+        description=description,
+        created_by=created_by,
+        tech_owner=tech_owner,
+        users=users or ["jane", "bob"],
+        tags=tags or ["finance", "automation"],
+        source_path=source_path,
+        scorecard=ScorecardSummary(
+            latest_composite=composite,
+            latest_scores=scores
+            or {
+                "correctness": 0.85,
+                "security": 0.90,
+                "maintainability": 0.55,
+                "documentation": 0.60,
+                "testability": 0.40,
+            },
+            trend=trend,
+            total_scores=total_scores,
+            red_flags=red_flags,
+        ),
+    )
+
+
+# --- Header ---
+
+
+class TestHeader:
+    def test_includes_tool_name(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(name="My Tool")
+        doc = gen.generate(tool)
+        assert "# Knowledge Transfer: My Tool" in doc
+
+
+# --- Overview ---
+
+
+class TestOverview:
+    def test_includes_purpose(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(description="Handles finance reports")
+        doc = gen.generate(tool)
+        assert "Handles finance reports" in doc
+
+    def test_includes_tier(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(tier=ToolTier.T2)
+        doc = gen.generate(tool)
+        assert "T2" in doc
+
+    def test_includes_tech_owner(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(tech_owner="dave")
+        doc = gen.generate(tool)
+        assert "dave" in doc
+
+    def test_includes_users(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(users=["alice", "bob"])
+        doc = gen.generate(tool)
+        assert "alice" in doc
+        assert "bob" in doc
+
+    def test_includes_tags(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(tags=["finance", "automation"])
+        doc = gen.generate(tool)
+        assert "finance" in doc
+
+    def test_no_description_shows_not_documented(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(description="")
+        doc = gen.generate(tool)
+        assert "Not documented" in doc
+
+    def test_no_tech_owner_shows_unassigned(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(tech_owner=None)
+        doc = gen.generate(tool)
+        assert "Unassigned" in doc
+
+
+# --- Architecture ---
+
+
+class TestArchitecture:
+    def test_no_source_shows_not_available(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(source_path="")
+        doc = gen.generate(tool)
+        assert "not available" in doc.lower()
+
+    def test_with_source_file(self, tmp_path):
+        source = tmp_path / "tool.py"
+        source.write_text(
+            "import requests\n"
+            "import json\n"
+            "\n"
+            "class Categorizer:\n"
+            "    def categorize(self, data):\n"
+            "        return data\n"
+            "\n"
+            "def helper():\n"
+            "    pass\n"
+        )
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(source_path=str(source))
+        doc = gen.generate(tool)
+        assert "Categorizer" in doc
+        assert "requests" in doc
+
+
+# --- Quality Profile ---
+
+
+class TestQualityProfile:
+    def test_includes_composite_score(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(composite=0.72)
+        doc = gen.generate(tool)
+        assert "0.72" in doc
+
+    def test_includes_trend(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(trend="improving")
+        doc = gen.generate(tool)
+        assert "improving" in doc
+
+    def test_includes_strongest_dimensions(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(
+            scores={
+                "correctness": 0.85,
+                "security": 0.90,
+                "maintainability": 0.55,
+                "documentation": 0.60,
+                "testability": 0.40,
+            }
+        )
+        doc = gen.generate(tool)
+        assert "security" in doc.lower()
+        assert "Strongest" in doc
+
+    def test_red_flags_shown(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(red_flags=2)
+        doc = gen.generate(tool)
+        assert "2" in doc
+        assert "red-tier" in doc.lower()
+
+    def test_no_red_flags(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(red_flags=0)
+        doc = gen.generate(tool)
+        assert "None" in doc
+
+
+# --- Risk Assessment ---
+
+
+class TestRiskAssessment:
+    def test_test_coverage_comprehensive(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(scores={"testability": 0.9})
+        doc = gen.generate(tool)
+        assert "Comprehensive" in doc
+
+    def test_test_coverage_basic(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(scores={"testability": 0.6})
+        doc = gen.generate(tool)
+        assert "Basic" in doc
+
+    def test_test_coverage_insufficient(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(scores={"testability": 0.2})
+        doc = gen.generate(tool)
+        assert "Insufficient" in doc
+
+    def test_bus_factor_single(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(users=["alice"])
+        doc = gen.generate(tool)
+        assert "high risk" in doc.lower()
+
+    def test_bus_factor_multiple(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(users=["alice", "bob", "charlie"])
+        doc = gen.generate(tool)
+        assert "3" in doc
+
+
+# --- Maintenance Guide ---
+
+
+class TestMaintenanceGuide:
+    def test_includes_source_location(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(source_path="/tools/categorizer.py")
+        doc = gen.generate(tool)
+        assert "/tools/categorizer.py" in doc
+
+    def test_known_issues_from_low_scores(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(
+            scores={
+                "correctness": 0.85,
+                "testability": 0.3,
+            }
+        )
+        doc = gen.generate(tool)
+        assert "testability" in doc.lower()
+        assert "needs improvement" in doc.lower()
+
+    def test_detects_main_block(self, tmp_path):
+        source = tmp_path / "tool.py"
+        source.write_text(
+            'import argparse\n\ndef main():\n    pass\n\nif __name__ == "__main__":\n    main()\n'
+        )
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool(source_path=str(source))
+        doc = gen.generate(tool)
+        assert "How to run" in doc
+
+
+# --- Scorecard History ---
+
+
+class TestScorecardHistory:
+    def test_no_storage_shows_not_available(self):
+        gen = KnowledgeTransferGenerator(storage=None)
+        tool = _make_tool()
+        doc = gen.generate(tool)
+        assert "not available" in doc.lower()
+
+    def test_no_scores_shows_no_events(self):
+        storage = MagicMock()
+        storage.query.return_value = []
+        gen = KnowledgeTransferGenerator(storage=storage)
+        tool = _make_tool(source_path="/tools/test.py")
+        doc = gen.generate(tool)
+        assert "No scoring events" in doc
+
+    def test_renders_score_table(self):
+        now = datetime.now()
+        scores = [
+            ScoreResult(
+                user="alice",
+                composite_score=0.75,
+                files_touched=["/tools/test.py"],
+                timestamp=now - timedelta(days=1),
+            ),
+            ScoreResult(
+                user="bob",
+                composite_score=0.80,
+                files_touched=["/tools/test.py"],
+                timestamp=now,
+            ),
+        ]
+        storage = MagicMock()
+        storage.query.return_value = scores
+        gen = KnowledgeTransferGenerator(storage=storage)
+        tool = _make_tool(source_path="/tools/test.py")
+        doc = gen.generate(tool)
+        assert "| Date |" in doc
+        assert "0.75" in doc
+        assert "0.80" in doc
+        assert "alice" in doc
+        assert "bob" in doc
+
+
+# --- CodeAnalysis ---
+
+
+class TestCodeAnalysis:
+    def test_basic_analysis(self, tmp_path):
+        source = tmp_path / "test.py"
+        code = (
+            "import os\nimport requests\n\nclass MyClass:\n    pass\n\ndef my_func():\n    pass\n"
+        )
+        source.write_text(code)
+        analysis = CodeAnalysis(source, code)
+
+        assert analysis.line_count == 8
+        assert "MyClass" in analysis.classes
+        assert "my_func" in analysis.functions
+        assert "os" in analysis.stdlib_imports
+        assert "requests" in analysis.third_party_imports
+
+    def test_syntax_error_handled(self, tmp_path):
+        source = tmp_path / "bad.py"
+        code = "def broken(\n"
+        source.write_text(code)
+        analysis = CodeAnalysis(source, code)
+        assert analysis.tree is None
+        assert analysis.line_count == 1
+
+
+# --- Full Document ---
+
+
+class TestFullDocument:
+    def test_all_sections_present(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool()
+        doc = gen.generate(tool)
+
+        assert "# Knowledge Transfer" in doc
+        assert "## Overview" in doc
+        assert "## Architecture" in doc
+        assert "## Quality Profile" in doc
+        assert "## Risk Assessment" in doc
+        assert "## Maintenance Guide" in doc
+        assert "## Scorecard History" in doc
+
+    def test_document_is_valid_markdown(self):
+        gen = KnowledgeTransferGenerator()
+        tool = _make_tool()
+        doc = gen.generate(tool)
+        # Should start with a heading and end with newline
+        assert doc.startswith("# ")
+        assert doc.endswith("\n")


### PR DESCRIPTION
## Summary
- Implements `KnowledgeTransferGenerator` in `registry/workflows/knowledge_transfer.py`
- Generates 7-section Markdown documents: header, overview, architecture, quality profile, risk assessment, maintenance guide, scorecard history
- `CodeAnalysis` class provides AST-based source inspection: functions, classes, imports (stdlib vs third-party), line counts
- Quality profile highlights strongest/weakest dimensions, risk assessment covers test coverage, bus factor, complexity
- Maintenance guide detects CLI usage, `__main__` blocks, and surfaces low-scoring dimensions as known issues
- Scorecard history renders as a Markdown table from storage backend
- 30 tests covering all sections, edge cases, source analysis, and full document structure

## Test plan
- [x] 30 tests passing for knowledge transfer generator
- [x] Lint clean (ruff check)
- [x] Format clean (ruff format)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)