### PR TITLE
feat(api): REST API layer with FastAPI for remote scoring (#66)

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,1 @@
+"""REST API layer for rubric-gates remote scoring."""

--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,324 @@
+"""FastAPI application for rubric-gates REST API.
+
+Exposes scoring, gate evaluation, and tool registry endpoints.
+Supports optional API key authentication and rate limiting.
+
+Usage:
+    uvicorn api.app:create_app --factory
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import time
+from collections import defaultdict
+from typing import Any
+
+from fastapi import Depends, FastAPI, Header, HTTPException, Request, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+
+from api.schemas import (
+    ErrorResponse,
+    GateRequest,
+    GateResponse,
+    HealthResponse,
+    ScoreRequest,
+    ScoreResponse,
+    ToolDetailResponse,
+    ToolScoreRequest,
+    ToolScoreResponse,
+    ToolSummary,
+)
+
+
+# --- Configuration ---
+
+
+class APIConfig:
+    """API configuration with sensible defaults.
+
+    Attributes:
+        api_key: Optional API key for authentication. Empty string disables auth.
+        rate_limit: Max requests per window per client.
+        rate_window: Rate limit window in seconds.
+        cors_origins: Allowed CORS origins.
+        catalog_dir: Path to tool catalog data directory.
+    """
+
+    def __init__(
+        self,
+        api_key: str = "",
+        rate_limit: int = 60,
+        rate_window: int = 60,
+        cors_origins: list[str] | None = None,
+        catalog_dir: str = "",
+    ) -> None:
+        self.api_key = api_key
+        self.rate_limit = rate_limit
+        self.rate_window = rate_window
+        self.cors_origins = cors_origins or ["*"]
+        self.catalog_dir = catalog_dir
+
+
+# --- Rate limiter ---
+
+
+class RateLimiter:
+    """Simple in-memory sliding-window rate limiter."""
+
+    def __init__(self, max_requests: int = 60, window_seconds: int = 60) -> None:
+        self.max_requests = max_requests
+        self.window = window_seconds
+        self._requests: dict[str, list[float]] = defaultdict(list)
+
+    def check(self, client_id: str) -> bool:
+        """Return True if the request is allowed."""
+        now = time.time()
+        cutoff = now - self.window
+        # Prune old entries
+        self._requests[client_id] = [t for t in self._requests[client_id] if t > cutoff]
+        if len(self._requests[client_id]) >= self.max_requests:
+            return False
+        self._requests[client_id].append(now)
+        return True
+
+
+# --- App factory ---
+
+
+def create_app(config: APIConfig | None = None) -> FastAPI:
+    """Create and configure the FastAPI application.
+
+    Args:
+        config: API configuration. Uses defaults if not provided.
+
+    Returns:
+        Configured FastAPI app.
+    """
+    if config is None:
+        config = APIConfig()
+
+    try:
+        version = importlib.metadata.version("rubric-gates")
+    except importlib.metadata.PackageNotFoundError:
+        version = "0.1.0"
+
+    app = FastAPI(
+        title="rubric-gates API",
+        description="REST API for rubric-based code quality scoring and gate evaluation.",
+        version=version,
+        responses={
+            401: {"model": ErrorResponse},
+            429: {"model": ErrorResponse},
+        },
+    )
+
+    # CORS
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=config.cors_origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    # State
+    app.state.config = config
+    app.state.rate_limiter = RateLimiter(config.rate_limit, config.rate_window)
+
+    # --- Dependencies ---
+
+    async def verify_api_key(
+        request: Request,
+        x_api_key: str | None = Header(default=None),
+    ) -> None:
+        """Verify API key if authentication is configured."""
+        cfg: APIConfig = request.app.state.config
+        if not cfg.api_key:
+            return  # Auth disabled
+        if x_api_key != cfg.api_key:
+            raise HTTPException(status_code=401, detail="Invalid or missing API key.")
+
+    async def check_rate_limit(request: Request) -> None:
+        """Enforce per-client rate limiting."""
+        limiter: RateLimiter = request.app.state.rate_limiter
+        client_ip = request.client.host if request.client else "unknown"
+        if not limiter.check(client_ip):
+            raise HTTPException(status_code=429, detail="Rate limit exceeded.")
+
+    # --- Lazy loaders for scoring/gate/catalog ---
+
+    def _get_engine() -> Any:
+        from scorecard.engine import RubricEngine
+
+        if not hasattr(app.state, "_engine"):
+            app.state._engine = RubricEngine()
+        return app.state._engine
+
+    def _get_evaluator(profile: str = "") -> Any:
+        if hasattr(app.state, "_evaluator"):
+            return app.state._evaluator
+        from gate.tiers.evaluator import TierEvaluator
+
+        return TierEvaluator(profile=profile)
+
+    def _get_catalog() -> Any:
+        if hasattr(app.state, "_catalog"):
+            return app.state._catalog
+        from registry.catalog.catalog import ToolCatalog
+
+        catalog = ToolCatalog(data_dir=config.catalog_dir) if config.catalog_dir else ToolCatalog()
+        app.state._catalog = catalog
+        return catalog
+
+    # --- Routes ---
+
+    @app.get("/health", response_model=HealthResponse)
+    async def health() -> HealthResponse:
+        """Health check endpoint."""
+        return HealthResponse(status="ok", version=version)
+
+    @app.post(
+        "/score",
+        response_model=ScoreResponse,
+        dependencies=[Depends(verify_api_key), Depends(check_rate_limit)],
+    )
+    async def score(req: ScoreRequest) -> ScoreResponse:
+        """Score source code across all quality dimensions."""
+        engine = _get_engine()
+        result = engine.score(
+            code=req.code,
+            filename=req.filename,
+            user=req.user or "api",
+            skill_used=req.skill_used,
+        )
+        dimensions = {ds.dimension.value: ds.score for ds in result.dimension_scores}
+        return ScoreResponse(
+            composite_score=result.composite_score,
+            dimensions=dimensions,
+            result=result,
+        )
+
+    @app.post(
+        "/score-file",
+        response_model=ScoreResponse,
+        dependencies=[Depends(verify_api_key), Depends(check_rate_limit)],
+    )
+    async def score_file(file: UploadFile) -> ScoreResponse:
+        """Score an uploaded file."""
+        content = await file.read()
+        code = content.decode("utf-8")
+        filename = file.filename or "uploaded.py"
+        engine = _get_engine()
+        result = engine.score(code=code, filename=filename, user="api")
+        dimensions = {ds.dimension.value: ds.score for ds in result.dimension_scores}
+        return ScoreResponse(
+            composite_score=result.composite_score,
+            dimensions=dimensions,
+            result=result,
+        )
+
+    @app.post(
+        "/gate",
+        response_model=GateResponse,
+        dependencies=[Depends(verify_api_key), Depends(check_rate_limit)],
+    )
+    async def gate(req: GateRequest) -> GateResponse:
+        """Evaluate code through the quality gate."""
+        engine = _get_engine()
+        score_result = engine.score(
+            code=req.code,
+            filename=req.filename,
+            user=req.user or "api",
+        )
+        evaluator = _get_evaluator(profile=req.profile)
+        gate_result = evaluator.evaluate(score_result, req.code, req.filename)
+        return GateResponse(
+            tier=gate_result.tier,
+            blocked=gate_result.blocked,
+            findings_count=len(gate_result.pattern_findings),
+            advisory_messages=gate_result.advisory_messages,
+            result=gate_result,
+        )
+
+    @app.get(
+        "/tools",
+        response_model=list[ToolSummary],
+        dependencies=[Depends(verify_api_key), Depends(check_rate_limit)],
+    )
+    async def list_tools() -> list[ToolSummary]:
+        """List all registered tools with tier info."""
+        catalog = _get_catalog()
+        tools = catalog.list()
+        return [
+            ToolSummary(
+                name=t.name,
+                slug=t.slug,
+                tier=t.tier,
+                latest_composite=t.scorecard.latest_composite,
+                tags=t.tags,
+            )
+            for t in tools
+        ]
+
+    @app.get(
+        "/tools/{slug}",
+        response_model=ToolDetailResponse,
+        dependencies=[Depends(verify_api_key), Depends(check_rate_limit)],
+    )
+    async def get_tool(slug: str) -> ToolDetailResponse:
+        """Get detailed info for a specific tool."""
+        catalog = _get_catalog()
+        tool = catalog.get(slug)
+        if tool is None:
+            raise HTTPException(status_code=404, detail=f"Tool '{slug}' not found.")
+        return ToolDetailResponse(
+            name=tool.name,
+            slug=tool.slug,
+            description=tool.description,
+            tier=tool.tier,
+            created_by=tool.created_by,
+            tech_owner=tool.tech_owner,
+            users=tool.users,
+            scorecard=tool.scorecard,
+            tags=tool.tags,
+            metadata=tool.metadata,
+        )
+
+    @app.post(
+        "/tools/{slug}/score",
+        response_model=ToolScoreResponse,
+        dependencies=[Depends(verify_api_key), Depends(check_rate_limit)],
+    )
+    async def score_tool(slug: str, req: ToolScoreRequest) -> ToolScoreResponse:
+        """Score code and update a tool's scorecard."""
+        catalog = _get_catalog()
+        tool = catalog.get(slug)
+        if tool is None:
+            raise HTTPException(status_code=404, detail=f"Tool '{slug}' not found.")
+
+        engine = _get_engine()
+        result = engine.score(
+            code=req.code,
+            filename=req.filename,
+            user=req.user or "api",
+        )
+
+        # Update scorecard summary
+        dim_scores = {ds.dimension.value: ds.score for ds in result.dimension_scores}
+        updated_scorecard = tool.scorecard.model_copy(
+            update={
+                "latest_composite": result.composite_score,
+                "latest_scores": dim_scores,
+                "total_scores": tool.scorecard.total_scores + 1,
+            }
+        )
+        catalog.update(slug, {"scorecard": updated_scorecard.model_dump(mode="json")})
+
+        return ToolScoreResponse(
+            slug=slug,
+            score=result,
+            updated_scorecard=updated_scorecard,
+        )
+
+    return app

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,0 +1,109 @@
+"""Request and response schemas for the REST API.
+
+Thin wrappers around shared models to define API-specific fields
+(e.g. optional inputs, response envelopes).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from shared.models import GateResult, GateTier, ScoreResult, ScorecardSummary, ToolTier
+
+
+# --- Requests ---
+
+
+class ScoreRequest(BaseModel):
+    """Request body for POST /score."""
+
+    code: str = Field(..., min_length=1, description="Source code to score.")
+    filename: str = Field(default="untitled.py", description="Filename for context.")
+    user: str = Field(default="", description="User who generated the code.")
+    skill_used: str = Field(default="", description="Claude Code skill used.")
+
+
+class GateRequest(BaseModel):
+    """Request body for POST /gate."""
+
+    code: str = Field(..., min_length=1, description="Source code to evaluate.")
+    filename: str = Field(default="untitled.py", description="Filename for context.")
+    user: str = Field(default="", description="User who generated the code.")
+    profile: str = Field(default="", description="Threshold profile to use.")
+
+
+class ToolScoreRequest(BaseModel):
+    """Request body for POST /tools/{slug}/score."""
+
+    code: str = Field(..., min_length=1, description="Source code to score.")
+    filename: str = Field(default="untitled.py", description="Filename for context.")
+    user: str = Field(default="", description="User who generated the code.")
+
+
+# --- Responses ---
+
+
+class ScoreResponse(BaseModel):
+    """Response for POST /score."""
+
+    composite_score: float
+    dimensions: dict[str, float] = Field(default_factory=dict)
+    result: ScoreResult
+
+
+class GateResponse(BaseModel):
+    """Response for POST /gate."""
+
+    tier: GateTier
+    blocked: bool
+    findings_count: int
+    advisory_messages: list[str] = Field(default_factory=list)
+    result: GateResult
+
+
+class ToolSummary(BaseModel):
+    """Abbreviated tool info for GET /tools list."""
+
+    name: str
+    slug: str
+    tier: ToolTier
+    latest_composite: float = 0.0
+    tags: list[str] = Field(default_factory=list)
+
+
+class ToolDetailResponse(BaseModel):
+    """Response for GET /tools/{slug}."""
+
+    name: str
+    slug: str
+    description: str
+    tier: ToolTier
+    created_by: str
+    tech_owner: str | None
+    users: list[str] = Field(default_factory=list)
+    scorecard: ScorecardSummary
+    tags: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ToolScoreResponse(BaseModel):
+    """Response for POST /tools/{slug}/score."""
+
+    slug: str
+    score: ScoreResult
+    updated_scorecard: ScorecardSummary
+
+
+class HealthResponse(BaseModel):
+    """Response for GET /health."""
+
+    status: str = "ok"
+    version: str = ""
+
+
+class ErrorResponse(BaseModel):
+    """Standard error response."""
+
+    detail: str

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,464 @@
+"""Tests for REST API layer (issue #66).
+
+Uses httpx.AsyncClient with ASGI transport — no server needed.
+Patches scoring engine and catalog to avoid real scorer dependencies.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+
+from api.app import APIConfig, RateLimiter, create_app
+from api.schemas import (
+    ErrorResponse,
+    GateRequest,
+    HealthResponse,
+    ScoreRequest,
+    ScoreResponse,
+    ToolSummary,
+)
+from shared.models import (
+    DimensionScore,
+    GateResult,
+    GateTier,
+    ScoreResult,
+    ScorecardSummary,
+    ToolRegistryEntry,
+    ToolTier,
+)
+
+# --- Fixtures ---
+
+try:
+    from httpx import ASGITransport, AsyncClient
+
+    HAS_HTTPX = True
+except ImportError:
+    HAS_HTTPX = False
+
+pytestmark = pytest.mark.skipif(not HAS_HTTPX, reason="httpx not installed")
+
+
+def _mock_score_result(composite: float = 0.85) -> ScoreResult:
+    return ScoreResult(
+        user="api",
+        composite_score=composite,
+        dimension_scores=[
+            DimensionScore(
+                dimension="correctness",
+                score=0.9,
+                method="rule_based",
+            ),
+            DimensionScore(
+                dimension="security",
+                score=0.8,
+                method="rule_based",
+            ),
+        ],
+    )
+
+
+def _mock_gate_result() -> GateResult:
+    return GateResult(
+        tier=GateTier.GREEN,
+        score_result=_mock_score_result(),
+        blocked=False,
+        advisory_messages=["All checks passed."],
+    )
+
+
+def _mock_tool() -> ToolRegistryEntry:
+    return ToolRegistryEntry(
+        name="Expense Categorizer",
+        slug="expense-categorizer",
+        description="Categorizes expenses automatically",
+        tier=ToolTier.T1,
+        created_by="alice",
+        tech_owner="bob",
+        users=["alice", "bob"],
+        scorecard=ScorecardSummary(
+            latest_composite=0.85,
+            latest_scores={"correctness": 0.9, "security": 0.8},
+            total_scores=5,
+        ),
+        tags=["finance"],
+    )
+
+
+@pytest.fixture
+def app():
+    """Create app with mocked dependencies."""
+    config = APIConfig(catalog_dir="/tmp/test-catalog")
+    test_app = create_app(config)
+
+    mock_engine = MagicMock()
+    mock_engine.score.return_value = _mock_score_result()
+
+    mock_evaluator = MagicMock()
+    mock_evaluator.evaluate.return_value = _mock_gate_result()
+
+    mock_catalog = MagicMock()
+    mock_catalog.list.return_value = [_mock_tool()]
+    mock_catalog.get.return_value = _mock_tool()
+    mock_catalog.update.return_value = _mock_tool()
+
+    test_app.state._engine = mock_engine
+    test_app.state._catalog = mock_catalog
+    test_app.state._evaluator = mock_evaluator
+
+    return test_app
+
+
+@pytest.fixture
+def app_with_auth():
+    """Create app with API key authentication enabled."""
+    config = APIConfig(api_key="test-secret-key")
+    test_app = create_app(config)
+
+    mock_engine = MagicMock()
+    mock_engine.score.return_value = _mock_score_result()
+    test_app.state._engine = mock_engine
+
+    return test_app
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest_asyncio.fixture
+async def auth_client(app_with_auth):
+    transport = ASGITransport(app=app_with_auth)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+# --- Health ---
+
+
+class TestHealth:
+    @pytest.mark.asyncio
+    async def test_health_returns_ok(self, client: AsyncClient):
+        resp = await client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert "version" in data
+
+    @pytest.mark.asyncio
+    async def test_health_no_auth_required(self, auth_client: AsyncClient):
+        """Health endpoint should not require API key."""
+        resp = await auth_client.get("/health")
+        assert resp.status_code == 200
+
+
+# --- Score ---
+
+
+class TestScore:
+    @pytest.mark.asyncio
+    async def test_score_basic(self, client: AsyncClient):
+        resp = await client.post(
+            "/score",
+            json={"code": "print('hello')", "filename": "hello.py"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["composite_score"] == 0.85
+        assert "correctness" in data["dimensions"]
+        assert "result" in data
+
+    @pytest.mark.asyncio
+    async def test_score_minimal(self, client: AsyncClient):
+        resp = await client.post("/score", json={"code": "x = 1"})
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_score_empty_code_rejected(self, client: AsyncClient):
+        resp = await client.post("/score", json={"code": ""})
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_score_missing_code_rejected(self, client: AsyncClient):
+        resp = await client.post("/score", json={})
+        assert resp.status_code == 422
+
+
+# --- Score File ---
+
+
+class TestScoreFile:
+    @pytest.mark.asyncio
+    async def test_score_file_upload(self, client: AsyncClient):
+        resp = await client.post(
+            "/score-file",
+            files={"file": ("test.py", b"print('hello')", "text/plain")},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["composite_score"] == 0.85
+
+
+# --- Gate ---
+
+
+class TestGate:
+    @pytest.mark.asyncio
+    async def test_gate_basic(self, client: AsyncClient):
+        resp = await client.post(
+            "/gate",
+            json={"code": "print('hello')", "filename": "hello.py"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["tier"] == "green"
+        assert data["blocked"] is False
+        assert "advisory_messages" in data
+
+    @pytest.mark.asyncio
+    async def test_gate_with_profile(self, client: AsyncClient):
+        resp = await client.post(
+            "/gate",
+            json={
+                "code": "x = 1",
+                "filename": "x.py",
+                "profile": "strict",
+            },
+        )
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_gate_empty_code_rejected(self, client: AsyncClient):
+        resp = await client.post("/gate", json={"code": ""})
+        assert resp.status_code == 422
+
+
+# --- Tools ---
+
+
+class TestToolsList:
+    @pytest.mark.asyncio
+    async def test_list_tools(self, client: AsyncClient):
+        resp = await client.get("/tools")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["slug"] == "expense-categorizer"
+        assert data[0]["tier"] == "T1"
+
+    @pytest.mark.asyncio
+    async def test_list_tools_empty(self, app, client: AsyncClient):
+        app.state._catalog.list.return_value = []
+        resp = await client.get("/tools")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+class TestToolDetail:
+    @pytest.mark.asyncio
+    async def test_get_tool(self, client: AsyncClient):
+        resp = await client.get("/tools/expense-categorizer")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "Expense Categorizer"
+        assert data["tier"] == "T1"
+        assert data["scorecard"]["latest_composite"] == 0.85
+
+    @pytest.mark.asyncio
+    async def test_get_tool_not_found(self, app, client: AsyncClient):
+        app.state._catalog.get.return_value = None
+        resp = await client.get("/tools/nonexistent")
+        assert resp.status_code == 404
+
+
+class TestToolScore:
+    @pytest.mark.asyncio
+    async def test_score_tool(self, client: AsyncClient):
+        resp = await client.post(
+            "/tools/expense-categorizer/score",
+            json={"code": "def categorize(): pass"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["slug"] == "expense-categorizer"
+        assert "score" in data
+        assert "updated_scorecard" in data
+
+    @pytest.mark.asyncio
+    async def test_score_tool_not_found(self, app, client: AsyncClient):
+        app.state._catalog.get.return_value = None
+        resp = await client.post(
+            "/tools/nonexistent/score",
+            json={"code": "x = 1"},
+        )
+        assert resp.status_code == 404
+
+
+# --- Authentication ---
+
+
+class TestAuthentication:
+    @pytest.mark.asyncio
+    async def test_no_key_returns_401(self, auth_client: AsyncClient):
+        resp = await auth_client.post("/score", json={"code": "x = 1"})
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_wrong_key_returns_401(self, auth_client: AsyncClient):
+        resp = await auth_client.post(
+            "/score",
+            json={"code": "x = 1"},
+            headers={"X-API-Key": "wrong-key"},
+        )
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_correct_key_allowed(self, auth_client: AsyncClient):
+        resp = await auth_client.post(
+            "/score",
+            json={"code": "x = 1"},
+            headers={"X-API-Key": "test-secret-key"},
+        )
+        assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_auth_disabled_allows_all(self, client: AsyncClient):
+        resp = await client.post("/score", json={"code": "x = 1"})
+        assert resp.status_code == 200
+
+
+# --- Rate Limiting ---
+
+
+class TestRateLimiter:
+    def test_allows_within_limit(self):
+        limiter = RateLimiter(max_requests=3, window_seconds=60)
+        assert limiter.check("client1") is True
+        assert limiter.check("client1") is True
+        assert limiter.check("client1") is True
+
+    def test_blocks_over_limit(self):
+        limiter = RateLimiter(max_requests=2, window_seconds=60)
+        assert limiter.check("client1") is True
+        assert limiter.check("client1") is True
+        assert limiter.check("client1") is False
+
+    def test_independent_clients(self):
+        limiter = RateLimiter(max_requests=1, window_seconds=60)
+        assert limiter.check("client1") is True
+        assert limiter.check("client2") is True
+        assert limiter.check("client1") is False
+
+    def test_window_expiry(self):
+        limiter = RateLimiter(max_requests=1, window_seconds=0)
+        assert limiter.check("client1") is True
+        # Window of 0 seconds means everything is expired immediately
+        assert limiter.check("client1") is True
+
+
+class TestRateLimitEndpoint:
+    @pytest.mark.asyncio
+    async def test_rate_limit_enforced(self):
+        config = APIConfig(rate_limit=2, rate_window=60)
+        test_app = create_app(config)
+        mock_engine = MagicMock()
+        mock_engine.score.return_value = _mock_score_result()
+        test_app.state._engine = mock_engine
+
+        transport = ASGITransport(app=test_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            await c.post("/score", json={"code": "x = 1"})
+            await c.post("/score", json={"code": "x = 2"})
+            resp = await c.post("/score", json={"code": "x = 3"})
+            assert resp.status_code == 429
+
+
+# --- Schema models ---
+
+
+class TestSchemas:
+    def test_score_request_validation(self):
+        req = ScoreRequest(code="x = 1")
+        assert req.filename == "untitled.py"
+
+    def test_gate_request_validation(self):
+        req = GateRequest(code="x = 1")
+        assert req.profile == ""
+
+    def test_health_response(self):
+        resp = HealthResponse(status="ok", version="1.0.0")
+        assert resp.status == "ok"
+
+    def test_error_response(self):
+        resp = ErrorResponse(detail="something went wrong")
+        assert resp.detail == "something went wrong"
+
+    def test_tool_summary(self):
+        ts = ToolSummary(name="Test", slug="test", tier=ToolTier.T0)
+        assert ts.latest_composite == 0.0
+
+    def test_score_response_model(self):
+        resp = ScoreResponse(
+            composite_score=0.85,
+            dimensions={"correctness": 0.9},
+            result=_mock_score_result(),
+        )
+        assert resp.composite_score == 0.85
+
+
+# --- OpenAPI docs ---
+
+
+class TestOpenAPI:
+    @pytest.mark.asyncio
+    async def test_openapi_available(self, client: AsyncClient):
+        resp = await client.get("/openapi.json")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["info"]["title"] == "rubric-gates API"
+        assert "/score" in data["paths"]
+        assert "/gate" in data["paths"]
+        assert "/tools" in data["paths"]
+        assert "/health" in data["paths"]
+
+    @pytest.mark.asyncio
+    async def test_docs_available(self, client: AsyncClient):
+        resp = await client.get("/docs")
+        assert resp.status_code == 200
+
+
+# --- CORS ---
+
+
+class TestCORS:
+    @pytest.mark.asyncio
+    async def test_cors_headers_present(self, client: AsyncClient):
+        resp = await client.options(
+            "/score",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        assert "access-control-allow-origin" in resp.headers
+
+
+# --- App factory ---
+
+
+class TestAppFactory:
+    def test_create_app_defaults(self):
+        app = create_app()
+        assert app.title == "rubric-gates API"
+
+    def test_create_app_custom_config(self):
+        config = APIConfig(api_key="secret", rate_limit=10)
+        app = create_app(config)
+        assert app.state.config.api_key == "secret"
+        assert app.state.config.rate_limit == 10


### PR DESCRIPTION
## Summary
- `api/` module with FastAPI app factory (`create_app`) exposing 7 endpoints:
  - `POST /score` — score code string across all quality dimensions
  - `POST /score-file` — score uploaded file
  - `POST /gate` — evaluate code through quality gate (tier + findings)
  - `GET /tools` — list registered tools with tier info
  - `GET /tools/{slug}` — tool details with scorecard
  - `POST /tools/{slug}/score` — score and update tool's scorecard
  - `GET /health` — health check with version info
- Pydantic request/response schemas in `api/schemas.py`
- Optional API key auth via `X-API-Key` header
- In-memory sliding-window rate limiter (configurable per-endpoint)
- CORS middleware for browser-based dashboards
- OpenAPI docs auto-generated at `/docs`
- All dependencies lazy-imported and injectable via `app.state` for testing

## Test plan
- [x] 36 tests using `httpx.AsyncClient` with ASGI transport (no server needed)
- [x] Tests cover: all endpoints, auth (enabled/disabled), rate limiting, schemas, OpenAPI, CORS, app factory
- [x] All mocked — no real scorer/catalog dependencies
- [x] Lint clean (`ruff check`), formatted (`ruff format`)

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)